### PR TITLE
x-axis bin range investigations

### DIFF
--- a/src/plots/Histogram.stories.tsx
+++ b/src/plots/Histogram.stories.tsx
@@ -75,7 +75,7 @@ export const PreBinnedContinuous3 = () => <Histogram
     name: 'series 2'
   }
   ]}
-  xLabel="numeric var"
+  xLabel="observation date"
   yLabel="count"
   mode="stack"
   binWidth={0.3}

--- a/src/plots/Histogram.stories.tsx
+++ b/src/plots/Histogram.stories.tsx
@@ -51,7 +51,7 @@ export const PreBinnedContinuous2 = () => <Histogram
   onPlotUpdate={action('state updated')}
   onSelected={action('selection made')}
   data={[{
-    x: [0.25, 0.55, 0.85],
+    x: [0.1, 0.4, 0.7],
     y: randomData(3).map((x) => Math.floor(100*x)),
     name: 'foo'
   }]}
@@ -65,12 +65,12 @@ export const PreBinnedContinuous3 = () => <Histogram
   onPlotUpdate={action('state updated')}
   onSelected={action('selection made')}
   data={[{
-    x: [0.25, 0.55, 0.85],
+    x: [0.1, 0.4, 0.7],
     y: randomData(3).map((x) => Math.floor(100*x)),
     name: 'series 1'
   },
   {
-    x: [0.25, 0.55, 0.85],
+    x: [0.1, 0.4, 0.7],
     y: randomData(3).map((x) => Math.floor(100*x)),
     name: 'series 2'
   }

--- a/src/plots/Histogram.stories.tsx
+++ b/src/plots/Histogram.stories.tsx
@@ -34,6 +34,76 @@ export const MultiVariate = () => <Histogram
   yLabel="percent content"
 />
 
+
+export const PreBinnedContinuous1 = () => <Histogram
+  onPlotUpdate={action('state updated')}
+  onSelected={action('selection made')}
+  data={[{
+    x: ["0.1-0.4", "0.4-0.7", "0.7-1.0"],
+    y: randomData(3).map((x) => Math.floor(100*x)),
+    name: 'foo'
+  }]}
+  xLabel="numeric var"
+  yLabel="count"
+/>
+
+export const PreBinnedContinuous2 = () => <Histogram
+  onPlotUpdate={action('state updated')}
+  onSelected={action('selection made')}
+  data={[{
+    x: [0.25, 0.55, 0.85],
+    y: randomData(3).map((x) => Math.floor(100*x)),
+    name: 'foo'
+  }]}
+  xLabel="numeric var"
+  yLabel="count"
+  binWidth={0.3}
+/>
+
+
+export const PreBinnedContinuous3 = () => <Histogram
+  onPlotUpdate={action('state updated')}
+  onSelected={action('selection made')}
+  data={[{
+    x: [0.25, 0.55, 0.85],
+    y: randomData(3).map((x) => Math.floor(100*x)),
+    name: 'series 1'
+  },
+  {
+    x: [0.25, 0.55, 0.85],
+    y: randomData(3).map((x) => Math.floor(100*x)),
+    name: 'series 2'
+  }
+  ]}
+  xLabel="numeric var"
+  yLabel="count"
+  mode="stack"
+  binWidth={0.3}
+/>
+
+
+export const PreBinnedDate = () => <Histogram
+  onPlotUpdate={action('state updated')}
+  onSelected={action('selection made')}
+  data={[{
+    x: ['2002', '2003', '2004'],
+    y: randomData(3).map((x) => Math.floor(100*x)),
+    name: 'series 1'
+  },
+  {
+    x:  ['2002', '2003', '2004'],
+    y: randomData(3).map((x) => Math.floor(100*x)),
+    name: 'series 2'
+  }
+  ]}
+  xLabel="numeric var"
+  yLabel="count"
+  mode="stack"
+  xType="date"
+  binWidth={365*24*60*60*1000} // measured in milliseconds! - will it work for leap years?
+/>
+
+
 function randomData(size: number) {
   const data: number[] = [];
   for (let i = 0; i < size; i++) {

--- a/src/plots/Histogram.tsx
+++ b/src/plots/Histogram.tsx
@@ -1,21 +1,38 @@
 import React from "react";
 import PlotlyPlot from "./PlotlyPlot";
 import { PlotComponentProps } from "./Types";
+import { Layout, AxisType } from "plotly.js";
 
 export interface Props extends PlotComponentProps<'name'|'x'|'y'> {
   xLabel: string;
   yLabel: string;
+  mode?: Layout['barmode'];
+  binWidth?: number;
+  xType?: AxisType;  // needed to force '2002' to be interpreted as a date
 }
 
 export default function Histogram(props: Props) {
-  const { xLabel, yLabel, ...plotlyProps } = props;
+  const { xLabel, yLabel, mode, binWidth, xType, data, ...plotlyProps } = props;
+
+  let hdata = data;
+  
+  if (binWidth) {
+    hdata = data.map( trace => ({
+      width: binWidth,
+      offset: binWidth/-2,
+      ...trace
+    }) );
+  }
+  
   const layout = {
     xaxis: {
-      title: xLabel
+      title: xLabel,
+      type: xType
     },
     yaxis: {
       title: yLabel
-    }
+    },
+    barmode: mode
   }
-  return <PlotlyPlot {...plotlyProps} layout={layout} type="bar"/>
+  return <PlotlyPlot data={hdata} {...plotlyProps} layout={layout} type="bar"/>
 }

--- a/src/plots/Histogram.tsx
+++ b/src/plots/Histogram.tsx
@@ -19,7 +19,7 @@ export default function Histogram(props: Props) {
   if (binWidth) {
     hdata = data.map( trace => ({
       width: binWidth,
-      offset: binWidth/-2,
+      offset: 0,
       ...trace
     }) );
   }

--- a/src/plots/PlotlyPlot.tsx
+++ b/src/plots/PlotlyPlot.tsx
@@ -32,7 +32,7 @@ const Plot = lazy(() => import('react-plotly.js'));
  * @param props 
  */
 export default function PlotlyPlot<T extends PlotDataKey>(props: Props<T>) {
-  const { data, layout = {}, frames = null, onPlotUpdate, mode, type } = props;
+  const { data, layout = {}, frames = null, onPlotUpdate, onSelected, mode, type } = props;
 
   const [ state, updateState ] = useState<Figure>({
     data: data.map(trace => ({
@@ -57,6 +57,7 @@ export default function PlotlyPlot<T extends PlotDataKey>(props: Props<T>) {
         frames={state.frames || undefined}
         onInitialized={handleUpdate}
         onUpdate={handleUpdate}
+        onSelected={onSelected}
       />
     </Suspense>
   )

--- a/src/plots/Types.ts
+++ b/src/plots/Types.ts
@@ -15,7 +15,7 @@ export interface PlotComponentProps<T extends keyof PlotData> {
   /** Style to be applied to container div element */
   style?: CSSProperties;
   /** Callback function to handle selection */
-  onSelection?: (range: [ number, number ]) => void;
+  onSelected?: (data: any) => void;
   /** Callback function to handle plot state change */
   onPlotUpdate?: (plotState: unknown) => void;
 }


### PR DESCRIPTION
If we are using our own back ends to bin data for histograms, then we have to think about how to pass the pre-binned data through to Plotly so that we can take advantage of its user-selection tools.

User-selections would be good for creating ranges to add as application-wide filters (e.g. in a date picker or numeric variable range picker).

I soon realised that the example story "PreBinnedContinuous1" is almost completely useless.  Providing the bin ranges as string labels e.g. "0.1-0.2" means that when the user does a "box select", the x-range emitted is meaningless (well, it's 1 unit per bin, so maybe not completely).

I added the binWidth prop so that you can provide the x data as the left hand limit of each bin - see PreBinnedContinuous2.  The x range from the user selection is now meaningful.

Then I checked what happened with multiple data series in PreBinnedContinuous3 - one way to make it work is to stack the bars - so I added the mode prop for that.

Finally - I started looking at date-based data.  Bare year data needs coaxing into date format with the "xType" property passed to the layout.xaxis.type parameter.

The date handling isn't ideal...  Dates provided as "2002" are displayed as "1 Jan 2002".  If we know a priori if the data is day, month or year-resolution then I think we can set the date format appropriately.  Likewise the x-axis tics and labels could be formatted appropriately.

I added an 'action' for onSelected - so you can see what payload that has. Its range.x property is what we need, e.g.

`[ "2002-11-02", "2004-12-31" ]`  (actually the values are returned in the reverse order, oddly)

but the adapter will need to convert this into the appropriate resolution and bin boundaries, e.g. `[ "2003", "2004" ]`

Lots to discuss.