### PR TITLE
Range control widgets

### DIFF
--- a/src/components/widgets/NumericInput.tsx
+++ b/src/components/widgets/NumericInput.tsx
@@ -14,7 +14,7 @@ export type NumericInputProps = {
   /** Maximum allowed value (inclusive) */
   maxValue?: number;
   /** Function to invoke when value changes. */
-  onValueChange: (newValue: number) => void;
+  onValueChange: (newValue?: number) => void;
   /** UI Label for the widget. Optional */
   label?: string;
   /** Additional styles for component container. Optional. */
@@ -65,14 +65,19 @@ export default function NumericInput({
   useEffect(() => {
     // if the min or max change
     // run the controlledValue through the bounds checker
-    // to reset the error states as required
+    // to fix controlledValue or reset the error states as required
     const newValue = boundsCheckedValue(controlledValue);
     if (newValue !== undefined) onValueChange(newValue);
   }, [minValue, maxValue]);
 
   const handleChange = (event: any) => {
-    const newValue = boundsCheckedValue(Number(event.target.value));
-    if (newValue !== undefined) onValueChange(newValue);
+    if (event.target.value.length > 0) {
+      const newValue = boundsCheckedValue(Number(event.target.value));
+      if (newValue !== undefined) onValueChange(newValue);
+    } else {
+      // allows user to clear the input box
+      onValueChange(undefined);
+    }
   };
 
   return (

--- a/src/components/widgets/NumericInput.tsx
+++ b/src/components/widgets/NumericInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 import { Typography, TextField } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
@@ -6,7 +6,9 @@ import { DARK_GRAY, MEDIUM_GRAY } from '../../constants/colors';
 
 export type NumericInputProps = {
   /** The starting value of the widget. */
-  defaultValue: number | undefined;
+  defaultValue?: number;
+  /** Externally controlled value. */
+  slaveValue?: number;
   /** Minimum allowed value (inclusive) */
   minValue?: number;
   /** Maximum allowed value (inclusive) */
@@ -21,6 +23,7 @@ export type NumericInputProps = {
 
 export default function NumericInput({
   defaultValue,
+  slaveValue,
   minValue,
   maxValue,
   onValueChange,
@@ -41,8 +44,10 @@ export default function NumericInput({
   });
   const classes = useStyles();
 
-  const handleChange = (event: any) => {
-    let newValue = Number(event.target.value);
+  const setValueSafely = (newValue?: number) => {
+    if (newValue === undefined) {
+      return;
+    }
     if (minValue !== undefined && newValue < minValue) {
       newValue = minValue;
       setErrorState({
@@ -61,6 +66,17 @@ export default function NumericInput({
     setValue(newValue);
     onValueChange(newValue);
   };
+
+  const handleChange = (event: any) => {
+    let newValue = Number(event.target.value);
+    setValueSafely(newValue);
+  };
+
+  // watch slaveValue for changes
+  // and set our value to the same thing
+  useEffect(() => {
+    setValueSafely(slaveValue);
+  }, [slaveValue]);
 
   return (
     <div

--- a/src/components/widgets/NumericInput.tsx
+++ b/src/components/widgets/NumericInput.tsx
@@ -45,9 +45,7 @@ export default function NumericInput({
   const classes = useStyles();
 
   const setValueSafely = (newValue?: number) => {
-    if (newValue === undefined) {
-      return;
-    }
+    if (newValue === undefined) return;
     if (minValue !== undefined && newValue < minValue) {
       newValue = minValue;
       setErrorState({

--- a/src/components/widgets/NumericInput.tsx
+++ b/src/components/widgets/NumericInput.tsx
@@ -1,12 +1,16 @@
 import React, { useState } from 'react';
 
-import { Typography, OutlinedInput } from '@material-ui/core';
+import { Typography, TextField } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import { DARK_GRAY, MEDIUM_GRAY } from '../../constants/colors';
 
 export type NumericInputProps = {
-  /** The current value of the widget. */
-  value: number | undefined;
+  /** The starting value of the widget. */
+  defaultValue: number | undefined;
+  /** Minimum allowed value (inclusive) */
+  minValue?: number;
+  /** Maximum allowed value (inclusive) */
+  maxValue?: number;
   /** Function to invoke when value changes. */
   onValueChange: (newValue: number) => void;
   /** UI Label for the widget. Optional */
@@ -16,19 +20,47 @@ export type NumericInputProps = {
 };
 
 export default function NumericInput({
-  value,
+  defaultValue,
+  minValue,
+  maxValue,
   onValueChange,
   label,
   containerStyles,
 }: NumericInputProps) {
+  const [myValue, setMyValue] = useState(defaultValue);
   const [focused, setFocused] = useState(false);
+  const [errorState, setErrorState] = useState({
+    error: false,
+    helperText: '',
+  });
 
   const useStyles = makeStyles({
     root: {
-      height: 30, // default height is 56 and is waaaay too tall
+      height: 32, // default height is 56 and is waaaay too tall
     },
   });
   const classes = useStyles();
+
+  const handleChange = (event: any) => {
+    let newValue = Number(event.target.value);
+    if (minValue !== undefined && newValue < minValue) {
+      newValue = minValue;
+      setErrorState({
+        error: true,
+        helperText: `Sorry, value can't go below ${minValue}!`,
+      });
+    } else if (maxValue !== undefined && newValue > maxValue) {
+      newValue = maxValue;
+      setErrorState({
+        error: true,
+        helperText: `Sorry, value can't go above ${maxValue}!`,
+      });
+    } else {
+      setErrorState({ error: false, helperText: '' });
+    }
+    setMyValue(newValue);
+    onValueChange(newValue);
+  };
 
   return (
     <div
@@ -45,14 +77,13 @@ export default function NumericInput({
         </Typography>
       )}
       <div style={{ display: 'flex', flexDirection: 'row' }}>
-        <OutlinedInput
-          classes={classes}
-          defaultValue={value}
+        <TextField
+          InputProps={{ classes }}
+          value={myValue}
           type="number"
-          onChange={(event) => {
-            const newValue = Number(event.target.value);
-            onValueChange(newValue);
-          }}
+          variant="outlined"
+          onChange={handleChange}
+          {...errorState}
         />
       </div>
     </div>

--- a/src/components/widgets/NumericInput.tsx
+++ b/src/components/widgets/NumericInput.tsx
@@ -1,13 +1,12 @@
 import React, { useState } from 'react';
 
 import { Typography } from '@material-ui/core';
-import KeyboardArrowUpIcon from '@material-ui/icons/KeyboardArrowUp';
-import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
+import TextField from '@material-ui/core/TextField';
 import { DARK_GRAY, MEDIUM_GRAY } from '../../constants/colors';
 
 export type NumericInputProps = {
   /** The current value of the widget. */
-  value: number;
+  value: number | undefined;
   /** Function to invoke when value changes. */
   onValueChange: (newValue: number) => void;
   /** UI Label for the widget. Optional */
@@ -39,25 +38,15 @@ export default function NumericInput({
         </Typography>
       )}
       <div style={{ display: 'flex', flexDirection: 'row' }}>
-        <input
-          style={{
-            borderWidth: 0,
-            fontFamily: 'Roboto, Helvetica, Arial, sans-serif',
-            fontSize: '14px',
-            color: MEDIUM_GRAY,
-            width: 40,
+        <TextField
+          defaultValue={value}
+          variant="outlined"
+          size="small"
+          type="number"
+          onChange={(event) => {
+            const newValue = Number(event.target.value);
+            onValueChange(newValue);
           }}
-          value={value}
-        />
-        <KeyboardArrowUpIcon
-          htmlColor={MEDIUM_GRAY}
-          style={{ width: 20, height: 20 }}
-          onClick={() => onValueChange(value + 1)}
-        />
-        <KeyboardArrowDownIcon
-          htmlColor={MEDIUM_GRAY}
-          style={{ width: 20, height: 20 }}
-          onClick={() => onValueChange(value + -1)}
         />
       </div>
     </div>

--- a/src/components/widgets/NumericInput.tsx
+++ b/src/components/widgets/NumericInput.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
-import { Typography } from '@material-ui/core';
-import TextField from '@material-ui/core/TextField';
+import { Typography, OutlinedInput } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
 import { DARK_GRAY, MEDIUM_GRAY } from '../../constants/colors';
 
 export type NumericInputProps = {
@@ -23,6 +23,13 @@ export default function NumericInput({
 }: NumericInputProps) {
   const [focused, setFocused] = useState(false);
 
+  const useStyles = makeStyles({
+    root: {
+      height: 30, // default height is 56 and is waaaay too tall
+    },
+  });
+  const classes = useStyles();
+
   return (
     <div
       style={{ ...containerStyles }}
@@ -38,10 +45,9 @@ export default function NumericInput({
         </Typography>
       )}
       <div style={{ display: 'flex', flexDirection: 'row' }}>
-        <TextField
+        <OutlinedInput
+          classes={classes}
           defaultValue={value}
-          variant="outlined"
-          size="small"
           type="number"
           onChange={(event) => {
             const newValue = Number(event.target.value);

--- a/src/components/widgets/NumericInput.tsx
+++ b/src/components/widgets/NumericInput.tsx
@@ -27,7 +27,7 @@ export default function NumericInput({
   label,
   containerStyles,
 }: NumericInputProps) {
-  const [myValue, setMyValue] = useState(defaultValue);
+  const [value, setValue] = useState(defaultValue);
   const [focused, setFocused] = useState(false);
   const [errorState, setErrorState] = useState({
     error: false,
@@ -58,7 +58,7 @@ export default function NumericInput({
     } else {
       setErrorState({ error: false, helperText: '' });
     }
-    setMyValue(newValue);
+    setValue(newValue);
     onValueChange(newValue);
   };
 
@@ -79,7 +79,7 @@ export default function NumericInput({
       <div style={{ display: 'flex', flexDirection: 'row' }}>
         <TextField
           InputProps={{ classes }}
-          value={myValue}
+          value={value}
           type="number"
           variant="outlined"
           onChange={handleChange}

--- a/src/components/widgets/RangeInput.tsx
+++ b/src/components/widgets/RangeInput.tsx
@@ -1,0 +1,99 @@
+import React, { useState, useEffect } from 'react';
+
+import { Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import { DARK_GRAY, MEDIUM_GRAY } from '../../constants/colors';
+import NumericInput from './NumericInput';
+import { Range } from '../../types/general';
+
+export type RangeInputProps = {
+  /** Default value for lower end of range. Optional. */
+  defaultLower?: number;
+  /** Default value for upper end of range. Optional. */
+  defaultUpper?: number;
+  /** Minimum allowed value for lower bound. Optional. */
+  minLower?: number;
+  /** Maximum allowed value for upper bound. Optional. */
+  maxUpper?: number;
+  /** Function to invoke when range changes. */
+  onRangeChange: (newRange: Range) => void;
+  /** UI Label for the widget. Optional */
+  label?: string;
+  /** Label for lower bound widget. Optional. Default is Min */
+  lowerLabel?: string;
+  /** Label for upper bound widget. Optional. Default is Max */
+  upperLabel?: string;
+  /** Additional styles for component container. Optional. */
+  containerStyles?: React.CSSProperties;
+};
+
+export default function RangeInput({
+  defaultLower,
+  defaultUpper,
+  minLower,
+  maxUpper,
+  onRangeChange,
+  label,
+  lowerLabel = 'Min',
+  upperLabel = 'Max',
+  containerStyles,
+}: RangeInputProps) {
+  const [lower, setLowerValue] = useState<number | undefined>(defaultLower);
+  const [upper, setUpperValue] = useState<number | undefined>(defaultUpper);
+  const [focused, setFocused] = useState(false);
+
+  useEffect(() => {
+    if (lower !== undefined && upper !== undefined) {
+      onRangeChange({ min: lower, max: upper });
+    }
+  }, [lower, upper, onRangeChange]);
+
+  return (
+    <div
+      style={{ ...containerStyles }}
+      onMouseOver={() => setFocused(true)}
+      onMouseOut={() => setFocused(false)}
+    >
+      {label && (
+        <Typography
+          variant="button"
+          style={{ color: focused ? DARK_GRAY : MEDIUM_GRAY }}
+        >
+          {label}
+        </Typography>
+      )}
+      <div style={{ display: 'flex', flexDirection: 'row' }}>
+        <NumericInput
+          controlledValue={lower}
+          minValue={minLower}
+          maxValue={upper ?? maxUpper}
+          label={lowerLabel}
+          onValueChange={(newValue) => {
+            setLowerValue(newValue);
+          }}
+          containerStyles={{ margin: 25 }}
+        />
+        <div style={{ display: 'flex', flexDirection: 'row' }}>
+          <div style={{ margin: 25 }}>
+            <Typography
+              variant="button"
+              style={{ color: focused ? DARK_GRAY : MEDIUM_GRAY }}
+            >
+              to
+            </Typography>
+          </div>
+        </div>
+        <NumericInput
+          controlledValue={upper}
+          minValue={lower ?? minLower}
+          maxValue={maxUpper}
+          label={upperLabel}
+          onValueChange={(newValue) => {
+            setUpperValue(newValue);
+          }}
+          containerStyles={{ margin: 25 }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/widgets/RangeInput.tsx
+++ b/src/components/widgets/RangeInput.tsx
@@ -1,20 +1,21 @@
 import React, { useState, useEffect } from 'react';
 
 import { Typography } from '@material-ui/core';
-import { makeStyles } from '@material-ui/core/styles';
 import { DARK_GRAY, MEDIUM_GRAY } from '../../constants/colors';
 import NumericInput from './NumericInput';
 import { Range } from '../../types/general';
 
 export type RangeInputProps = {
-  /** Default value for lower end of range. Optional. */
-  defaultLower?: number;
-  /** Default value for upper end of range. Optional. */
-  defaultUpper?: number;
+  /** Default value for lower end of range. */
+  defaultLower: number;
+  /** Default value for upper end of range. */
+  defaultUpper: number;
   /** Minimum allowed value for lower bound. Optional. */
   minLower?: number;
   /** Maximum allowed value for upper bound. Optional. */
   maxUpper?: number;
+  /** Externally controlled range. Optional but recommended. */
+  controlledRange?: Range;
   /** Function to invoke when range changes. */
   onRangeChange: (newRange: Range) => void;
   /** UI Label for the widget. Optional */
@@ -32,21 +33,36 @@ export default function RangeInput({
   defaultUpper,
   minLower,
   maxUpper,
+  controlledRange,
   onRangeChange,
   label,
   lowerLabel = 'Min',
   upperLabel = 'Max',
   containerStyles,
 }: RangeInputProps) {
-  const [lower, setLowerValue] = useState<number | undefined>(defaultLower);
-  const [upper, setUpperValue] = useState<number | undefined>(defaultUpper);
+  // lower and upper ranges for internal/uncontrolled operation
+  const [lower, setLowerValue] = useState<number>(defaultLower);
+  const [upper, setUpperValue] = useState<number>(defaultUpper);
+
   const [focused, setFocused] = useState(false);
 
+  // listen for changes to the values of the two NumericInputs
+  // and communicate outwards via onRangeChange
   useEffect(() => {
     if (lower !== undefined && upper !== undefined) {
       onRangeChange({ min: lower, max: upper });
     }
   }, [lower, upper, onRangeChange]);
+
+  // listen for changes to the controlledRange min and max (if provided)
+  // and communicate those inwards to lower and upper
+  useEffect(() => {
+    if (controlledRange !== undefined) setLowerValue(controlledRange.min);
+  }, [controlledRange?.min]);
+
+  useEffect(() => {
+    if (controlledRange !== undefined) setUpperValue(controlledRange.max);
+  }, [controlledRange?.max]);
 
   return (
     <div
@@ -69,7 +85,7 @@ export default function RangeInput({
           maxValue={upper ?? maxUpper}
           label={lowerLabel}
           onValueChange={(newValue) => {
-            setLowerValue(newValue);
+            if (newValue !== undefined) setLowerValue(newValue);
           }}
           containerStyles={{ margin: 25 }}
         />
@@ -89,7 +105,7 @@ export default function RangeInput({
           maxValue={maxUpper}
           label={upperLabel}
           onValueChange={(newValue) => {
-            setUpperValue(newValue);
+            if (newValue !== undefined) setUpperValue(newValue);
           }}
           containerStyles={{ margin: 25 }}
         />

--- a/src/stories/widgets/NumericInput.stories.tsx
+++ b/src/stories/widgets/NumericInput.stories.tsx
@@ -11,14 +11,10 @@ export default {
 } as Meta;
 
 const Template: Story<NumericInputProps> = (args) => {
-  const [value, setValue] = useState<number | undefined>(args.value);
-
   return (
     <NumericInput
       {...args}
-      value={value}
       onValueChange={(newValue) => {
-        setValue(newValue);
         console.log(`set new value = ${newValue}`);
       }}
       containerStyles={{ ...args.containerStyles, margin: 25 }}
@@ -28,7 +24,7 @@ const Template: Story<NumericInputProps> = (args) => {
 
 export const Basic = Template.bind({});
 Basic.args = {
-  value: 42,
+  defaultValue: 42,
 };
 
 export const Labelled = Template.bind({});
@@ -48,4 +44,19 @@ NotSoWide.args = {
   containerStyles: {
     width: 100,
   },
+};
+
+export const Bounded = Template.bind({});
+Bounded.args = {
+  label: '0 <= x <= 5',
+  minValue: 0,
+  maxValue: 5,
+};
+
+export const BoundedInitialized = Template.bind({});
+BoundedInitialized.args = {
+  defaultValue: 3,
+  label: '0 <= x <= 5',
+  minValue: 0,
+  maxValue: 5,
 };

--- a/src/stories/widgets/NumericInput.stories.tsx
+++ b/src/stories/widgets/NumericInput.stories.tsx
@@ -60,3 +60,28 @@ BoundedInitialized.args = {
   minValue: 0,
   maxValue: 5,
 };
+
+export const ExternallyControlled: Story = () => {
+  const [linkedValue, setLinkedValue] = useState<number | undefined>();
+
+  return (
+    <>
+      <NumericInput
+        label="Master (unbounded)"
+        onValueChange={(newValue) => {
+          console.log(`master set new value = ${newValue}`);
+          setLinkedValue(newValue);
+        }}
+      />
+      <NumericInput
+        slaveValue={linkedValue}
+        label="Slave (0 <= x <= 5)"
+        minValue={0}
+        maxValue={5}
+        onValueChange={(newValue) => {
+          console.log(`slave set new value = ${newValue}`);
+        }}
+      />
+    </>
+  );
+};

--- a/src/stories/widgets/NumericInput.stories.tsx
+++ b/src/stories/widgets/NumericInput.stories.tsx
@@ -134,8 +134,10 @@ export const ControlledBounds: Story = () => {
         minValue={min}
         maxValue={max}
         onValueChange={(newValue) => {
-          setValue(newValue);
           console.log(`new value = ${newValue}`);
+          // for some reason the `newValue !== undefined` is needed because
+          // the `useState<number>(0)` has an initial value provided
+          if (newValue !== undefined) setValue(newValue);
         }}
         containerStyles={{ margin: 25 }}
       />
@@ -144,7 +146,7 @@ export const ControlledBounds: Story = () => {
         maxValue={max}
         label="Min"
         onValueChange={(newValue) => {
-          setMin(newValue);
+          if (newValue !== undefined) setMin(newValue);
         }}
         containerStyles={{ margin: 25 }}
       />
@@ -153,7 +155,7 @@ export const ControlledBounds: Story = () => {
         minValue={min}
         label="Max"
         onValueChange={(newValue) => {
-          setMax(newValue);
+          if (newValue !== undefined) setMax(newValue);
         }}
         containerStyles={{ margin: 25 }}
       />

--- a/src/stories/widgets/NumericInput.stories.tsx
+++ b/src/stories/widgets/NumericInput.stories.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import { Story, Meta } from '@storybook/react/types-6-0';
+
+import NumericInput, {
+  NumericInputProps,
+} from '../../components/widgets/NumericInput';
+
+export default {
+  title: 'Widgets/Numeric Input',
+  component: NumericInput,
+} as Meta;
+
+const Template: Story<NumericInputProps> = (args) => {
+  const [value, setValue] = useState<number | undefined>(args.value);
+
+  return (
+    <NumericInput
+      {...args}
+      value={value}
+      onValueChange={(newValue) => {
+        setValue(newValue);
+        console.log(`set new value = ${newValue}`);
+      }}
+      containerStyles={{ ...args.containerStyles, margin: 25 }}
+    />
+  );
+};
+
+export const Basic = Template.bind({});
+Basic.args = {
+  value: 42,
+};
+
+export const Labelled = Template.bind({});
+Labelled.args = {
+  ...Basic.args,
+  label: 'Labelled',
+};
+
+export const StartsEmpty = Template.bind({});
+StartsEmpty.args = {
+  label: 'Starts Empty',
+};

--- a/src/stories/widgets/NumericInput.stories.tsx
+++ b/src/stories/widgets/NumericInput.stories.tsx
@@ -15,7 +15,7 @@ const Template: Story<NumericInputProps> = (args) => {
     <NumericInput
       {...args}
       onValueChange={(newValue) => {
-        console.log(`set new value = ${newValue}`);
+        console.log(`new value = ${newValue}`);
       }}
       containerStyles={{ ...args.containerStyles, margin: 25 }}
     />
@@ -61,26 +61,101 @@ BoundedInitialized.args = {
   maxValue: 5,
 };
 
-export const ExternallyControlled: Story = () => {
-  const [linkedValue, setLinkedValue] = useState<number | undefined>();
+const ControlledTemplate: Story<NumericInputProps> = (args) => {
+  const [value, setValue] = useState<number>();
+  return (
+    <NumericInput
+      {...args}
+      controlledValue={value}
+      onValueChange={(newValue) => {
+        console.log(`new value = ${newValue}`);
+        setValue(newValue);
+      }}
+      containerStyles={{ ...args.containerStyles, margin: 25 }}
+    />
+  );
+};
+
+export const Controlled = ControlledTemplate.bind({});
+Controlled.args = {
+  label: 'Controlled uninitialised',
+};
+
+export const ControlledInitialized = ControlledTemplate.bind({});
+ControlledInitialized.args = {
+  label: 'Controlled initialised',
+  defaultValue: 5,
+};
+
+export const ControlledBounded = ControlledTemplate.bind({});
+ControlledBounded.args = {
+  label: 'Controlled (0 <= x <= 5)',
+  minValue: 0,
+  maxValue: 5,
+};
+
+export const ControlledLinkedPair: Story = () => {
+  const [linkedValue, setLinkedValue] = useState<number>();
 
   return (
     <>
       <NumericInput
-        label="Master (unbounded)"
+        controlledValue={linkedValue}
+        label="A"
         onValueChange={(newValue) => {
-          console.log(`master set new value = ${newValue}`);
+          console.log(`A new value = ${newValue}`);
           setLinkedValue(newValue);
         }}
+        containerStyles={{ margin: 25 }}
       />
       <NumericInput
-        slaveValue={linkedValue}
-        label="Slave (0 <= x <= 5)"
-        minValue={0}
-        maxValue={5}
+        controlledValue={linkedValue}
+        label="B"
         onValueChange={(newValue) => {
-          console.log(`slave set new value = ${newValue}`);
+          console.log(`B new value = ${newValue}`);
+          setLinkedValue(newValue);
         }}
+        containerStyles={{ margin: 25 }}
+      />
+    </>
+  );
+};
+
+export const ControlledBounds: Story = () => {
+  const [value, setValue] = useState<number>(0);
+  const [min, setMin] = useState<number>(-5);
+  const [max, setMax] = useState<number>(5);
+
+  return (
+    <>
+      <NumericInput
+        controlledValue={value}
+        label={`Value (${min} <= x <= ${max})`}
+        minValue={min}
+        maxValue={max}
+        onValueChange={(newValue) => {
+          setValue(newValue);
+          console.log(`new value = ${newValue}`);
+        }}
+        containerStyles={{ margin: 25 }}
+      />
+      <NumericInput
+        controlledValue={min}
+        maxValue={max}
+        label="Min"
+        onValueChange={(newValue) => {
+          setMin(newValue);
+        }}
+        containerStyles={{ margin: 25 }}
+      />
+      <NumericInput
+        controlledValue={max}
+        minValue={min}
+        label="Max"
+        onValueChange={(newValue) => {
+          setMax(newValue);
+        }}
+        containerStyles={{ margin: 25 }}
       />
     </>
   );

--- a/src/stories/widgets/NumericInput.stories.tsx
+++ b/src/stories/widgets/NumericInput.stories.tsx
@@ -41,3 +41,11 @@ export const StartsEmpty = Template.bind({});
 StartsEmpty.args = {
   label: 'Starts Empty',
 };
+
+export const NotSoWide = Template.bind({});
+NotSoWide.args = {
+  label: 'Not so wide',
+  containerStyles: {
+    width: 100,
+  },
+};

--- a/src/stories/widgets/RangeInput.stories.tsx
+++ b/src/stories/widgets/RangeInput.stories.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import { Story, Meta } from '@storybook/react/types-6-0';
+
+import RangeInput, {
+  RangeInputProps,
+} from '../../components/widgets/RangeInput';
+
+export default {
+  title: 'Widgets/Range Input',
+  component: RangeInput,
+} as Meta;
+
+const Template: Story<RangeInputProps> = (args) => {
+  return (
+    <RangeInput
+      {...args}
+      onRangeChange={(newRange) => {
+        console.log(`new range = ${newRange.min} to ${newRange.max}`);
+      }}
+      containerStyles={{ ...args.containerStyles, margin: 25 }}
+    />
+  );
+};
+
+export const Basic = Template.bind({});
+Basic.args = {
+  defaultLower: 1,
+  defaultUpper: 5,
+};
+
+export const Labelled = Template.bind({});
+Labelled.args = {
+  ...Basic.args,
+  label: 'Labelled',
+};
+
+export const StartsEmpty = Template.bind({});
+StartsEmpty.args = {
+  label: 'Starts Empty',
+};
+
+export const Bounded = Template.bind({});
+Bounded.args = {
+  label: 'Bounded (0 to 10)',
+  defaultLower: 1,
+  defaultUpper: 9,
+  minLower: 0,
+  maxUpper: 10,
+};
+
+export const FullyLabelled = Template.bind({});
+FullyLabelled.args = {
+  label: 'Select a range between 0 and 10',
+  minLower: 0,
+  maxUpper: 10,
+  lowerLabel: 'Lower bound',
+  upperLabel: 'Upper bound',
+};

--- a/src/stories/widgets/RangeInput.stories.tsx
+++ b/src/stories/widgets/RangeInput.stories.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import { Story, Meta } from '@storybook/react/types-6-0';
+import { Range } from '../../types/general';
 
 import RangeInput, {
   RangeInputProps,
@@ -34,11 +35,6 @@ Labelled.args = {
   label: 'Labelled',
 };
 
-export const StartsEmpty = Template.bind({});
-StartsEmpty.args = {
-  label: 'Starts Empty',
-};
-
 export const Bounded = Template.bind({});
 Bounded.args = {
   label: 'Bounded (0 to 10)',
@@ -51,8 +47,56 @@ Bounded.args = {
 export const FullyLabelled = Template.bind({});
 FullyLabelled.args = {
   label: 'Select a range between 0 and 10',
+  defaultLower: 1,
+  defaultUpper: 9,
   minLower: 0,
   maxUpper: 10,
   lowerLabel: 'Lower bound',
   upperLabel: 'Upper bound',
+};
+
+export const ControlledLinked: Story<RangeInputProps> = () => {
+  const [range, setRange] = useState<Range>();
+
+  // there must be a cleverer way to do this
+  // avoiding the cut and paste
+  const handleChangeA = useCallback(
+    (newRange) => {
+      console.log(`A: new range = ${newRange.min} to ${newRange.max}`);
+      setRange(newRange);
+    },
+    [setRange]
+  );
+
+  const handleChangeB = useCallback(
+    (newRange) => {
+      console.log(`B: new range = ${newRange.min} to ${newRange.max}`);
+      setRange(newRange);
+    },
+    [setRange]
+  );
+
+  const SharedRangeInputArgs = {
+    defaultLower: 1,
+    defaultUpper: 9,
+    minLower: 0,
+    maxUpper: 10,
+    controlledRange: range,
+    containerStyles: { margin: 25 },
+  };
+
+  return (
+    <>
+      <RangeInput
+        label="A"
+        onRangeChange={handleChangeA}
+        {...SharedRangeInputArgs}
+      />
+      <RangeInput
+        label="B"
+        onRangeChange={handleChangeB}
+        {...SharedRangeInputArgs}
+      />
+    </>
+  );
 };

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -10,3 +10,8 @@ export type ErrorManagement = {
   removeError: (error: Error) => void;
   clearAllErrors: () => void;
 };
+
+export type Range = {
+  min: number;
+  max: number;
+};


### PR DESCRIPTION
Added two new widgets:
1. NumericInput
2. RangeInput

The styling is not great (they are huge) but we'll fix that later.

`NumericInput` has two modes: controlled and uncontrolled.  The controlled version works a bit better when going outside the allowed range (minValue-maxValue).

`RangeInput` uses 2x `NumericInput` in controlled mode.  I'm not yet sure how it itself can be controlled externally (e.g. setting the numbers by dragging on a plot).  Maybe I'll have a look at that now.
