### PR TITLE
Remove uncontrolled behavior from date/number related inputs

### DIFF
--- a/src/components/plotControls/HistogramControls.tsx
+++ b/src/components/plotControls/HistogramControls.tsx
@@ -183,21 +183,19 @@ export default function HistogramControls({
             onOptionSelected={onSelectedUnitChange}
           />
         ) : null}
-        {displaySelectedRangeControls && selectedRangeBounds ? (
+        {displaySelectedRangeControls ? (
           valueType !== undefined && valueType === 'date' ? (
             <DateRangeInput
               label="Selected Range"
-              defaultRange={selectedRangeBounds as DateRange}
               rangeBounds={selectedRangeBounds as DateRange}
-              controlledRange={selectedRange as DateRange}
+              range={selectedRange as DateRange}
               onRangeChange={onSelectedRangeChange}
             />
           ) : (
             <NumberRangeInput
               label="Selected Range"
-              defaultRange={selectedRangeBounds as NumberRange}
               rangeBounds={selectedRangeBounds as NumberRange}
-              controlledRange={selectedRange as NumberRange}
+              range={selectedRange as NumberRange}
               onRangeChange={onSelectedRangeChange}
             />
           )

--- a/src/components/widgets/NumberAndDateInputs.tsx
+++ b/src/components/widgets/NumberAndDateInputs.tsx
@@ -6,10 +6,8 @@ import { DARK_GRAY, MEDIUM_GRAY } from '../../constants/colors';
 import { NumberOrDate } from '../../types/general';
 
 type BaseProps<M extends NumberOrDate> = {
-  /** The starting value of the widget. */
-  defaultValue?: M;
   /** Externally controlled value. */
-  controlledValue?: M;
+  value?: M;
   /** Minimum allowed value (inclusive) */
   minValue?: M;
   /** Maximum allowed value (inclusive) */
@@ -48,8 +46,7 @@ type BaseInputProps =
  * Not currently exported. But could be if needed.
  */
 function BaseInput({
-  defaultValue,
-  controlledValue,
+  value,
   minValue,
   maxValue,
   onValueChange,
@@ -70,7 +67,7 @@ function BaseInput({
   })();
 
   const boundsCheckedValue = (newValue?: NumberOrDate) => {
-    if (newValue === undefined) return;
+    if (newValue === undefined) return undefined;
     if (minValue !== undefined && newValue < minValue) {
       newValue = minValue;
       setErrorState({
@@ -86,15 +83,15 @@ function BaseInput({
     } else {
       setErrorState({ error: false, helperText: '' });
     }
-    return newValue;
+    return undefined;
   };
 
   useEffect(() => {
     // if the min or max change
     // run the controlledValue through the bounds checker
     // to fix controlledValue or reset the error states as required
-    const newValue = boundsCheckedValue(controlledValue);
-    if (newValue !== undefined) onValueChange(newValue);
+    const newValue = boundsCheckedValue(value);
+    if (newValue != null) onValueChange(newValue);
   }, [minValue, maxValue]);
 
   const handleChange = (event: any) => {
@@ -128,15 +125,10 @@ function BaseInput({
       <div style={{ display: 'flex', flexDirection: 'row' }}>
         <TextField
           InputProps={{ classes }}
-          defaultValue={
-            valueType === 'number'
-              ? defaultValue
-              : (defaultValue as Date)?.toISOString().substr(0, 10)
-          }
           value={
             valueType === 'number'
-              ? controlledValue
-              : (controlledValue as Date)?.toISOString().substr(0, 10)
+              ? value
+              : (value as Date)?.toISOString().substr(0, 10)
           }
           type={valueType}
           variant="outlined"

--- a/src/components/widgets/NumberAndDateRangeInputs.tsx
+++ b/src/components/widgets/NumberAndDateRangeInputs.tsx
@@ -11,12 +11,10 @@ import {
 } from '../../types/general';
 
 export type BaseProps<M extends NumberOrDateRange> = {
-  /** Default value for the range. */
-  defaultRange: M;
+  /** Externally controlled range. */
+  range?: M;
   /** Minimum and maximum allowed values for the user-inputted range. Optional. */
   rangeBounds?: M;
-  /** Externally controlled range. Optional but recommended. */
-  controlledRange?: M;
   /** Function to invoke when range changes. */
   onRangeChange?: (newRange: NumberOrDateRange) => void;
   /** UI Label for the widget. Optional */
@@ -55,9 +53,8 @@ type BaseInputProps =
  * Not currently exported. But could be if needed.
  */
 function BaseInput({
-  defaultRange,
+  range,
   rangeBounds,
-  controlledRange,
   onRangeChange,
   label,
   lowerLabel = 'Min',
@@ -65,30 +62,9 @@ function BaseInput({
   valueType,
   containerStyles,
 }: BaseInputProps) {
-  // lower and upper ranges for internal/uncontrolled operation
-  const [lower, setLower] = useState<NumberOrDate>(defaultRange.min);
-  const [upper, setUpper] = useState<NumberOrDate>(defaultRange.max);
-
   const [focused, setFocused] = useState(false);
 
-  // listen for changes to the values of the two NumberInputs
-  // and communicate outwards via onRangeChange
-  useEffect(() => {
-    if (onRangeChange && lower !== undefined && upper !== undefined) {
-      onRangeChange({ min: lower, max: upper } as NumberOrDateRange);
-    }
-  }, [lower, upper]);
-
-  // listen for changes to the controlledRange min and max (if provided)
-  // and communicate those inwards to lower and upper
-  useEffect(() => {
-    if (controlledRange !== undefined) setLower(controlledRange.min);
-  }, [controlledRange?.min]);
-
-  useEffect(() => {
-    if (controlledRange !== undefined) setUpper(controlledRange.max);
-  }, [controlledRange?.max]);
-
+  const { min, max } = range ?? {};
   return (
     <div
       style={{ ...containerStyles }}
@@ -106,22 +82,24 @@ function BaseInput({
       <div style={{ display: 'flex', flexDirection: 'row' }}>
         {valueType === 'number' ? (
           <NumberInput
-            controlledValue={lower as number}
+            value={min as number}
             minValue={rangeBounds?.min as number}
-            maxValue={(upper ?? rangeBounds?.max) as number}
+            maxValue={(max ?? rangeBounds?.max) as number}
             label={lowerLabel}
             onValueChange={(newValue) => {
-              if (newValue !== undefined) setLower(newValue as number);
+              if (newValue !== undefined && onRangeChange)
+                onRangeChange({ min: newValue, max } as NumberRange);
             }}
           />
         ) : (
           <DateInput
-            controlledValue={lower as Date}
+            value={min as Date}
             minValue={rangeBounds?.min as Date}
-            maxValue={(upper ?? rangeBounds?.max) as Date}
+            maxValue={(max ?? rangeBounds?.max) as Date}
             label={lowerLabel}
             onValueChange={(newValue) => {
-              if (newValue !== undefined) setLower(newValue as Date);
+              if (newValue !== undefined && onRangeChange)
+                onRangeChange({ min: newValue, max } as DateRange);
             }}
           />
         )}
@@ -137,22 +115,24 @@ function BaseInput({
         </div>
         {valueType === 'number' ? (
           <NumberInput
-            controlledValue={upper as number}
-            minValue={(lower ?? rangeBounds?.min) as number}
+            value={max as number}
+            minValue={(min ?? rangeBounds?.min) as number}
             maxValue={rangeBounds?.max as number}
             label={upperLabel}
             onValueChange={(newValue) => {
-              if (newValue !== undefined) setUpper(newValue as number);
+              if (newValue !== undefined && onRangeChange)
+                onRangeChange({ min, max: newValue } as NumberRange);
             }}
           />
         ) : (
           <DateInput
-            controlledValue={upper as Date}
-            minValue={(lower ?? rangeBounds?.min) as Date}
+            value={max as Date}
+            minValue={(min ?? rangeBounds?.min) as Date}
             maxValue={rangeBounds?.max as Date}
             label={upperLabel}
             onValueChange={(newValue) => {
-              if (newValue !== undefined) setUpper(newValue as Date);
+              if (newValue !== undefined && onRangeChange)
+                onRangeChange({ min, max: newValue } as DateRange);
             }}
           />
         )}

--- a/src/stories/widgets/DateInput.stories.tsx
+++ b/src/stories/widgets/DateInput.stories.tsx
@@ -25,7 +25,7 @@ const Template: Story<DateInputProps> = (args) => {
 
 export const Basic = Template.bind({});
 Basic.args = {
-  defaultValue: new Date('2021-12-21'),
+  value: new Date('2021-12-21'),
 };
 
 export const Labelled = Template.bind({});
@@ -48,7 +48,7 @@ Bounded.args = {
 
 export const BoundedInitialized = Template.bind({});
 BoundedInitialized.args = {
-  defaultValue: new Date('2005-01-01'),
+  value: new Date('2005-01-01'),
   label: '2000-01-01 to 2009-12-31',
   minValue: new Date('2000-01-01'),
   maxValue: new Date('2009-12-31'),
@@ -59,7 +59,7 @@ const ControlledTemplate: Story<DateInputProps> = (args) => {
   return (
     <DateInput
       {...args}
-      controlledValue={value}
+      value={value}
       onValueChange={(newValue) => {
         console.log(`new value = ${newValue}`);
         setValue(newValue as Date);
@@ -87,7 +87,7 @@ export const ControlledLinkedPair: Story = () => {
   return (
     <>
       <DateInput
-        controlledValue={linkedValue}
+        value={linkedValue}
         label="A"
         onValueChange={(newValue) => {
           console.log(`A new value = ${newValue}`);
@@ -96,7 +96,7 @@ export const ControlledLinkedPair: Story = () => {
         containerStyles={{ margin: 25 }}
       />
       <DateInput
-        controlledValue={linkedValue}
+        value={linkedValue}
         label="B"
         onValueChange={(newValue) => {
           console.log(`B new value = ${newValue}`);
@@ -116,7 +116,7 @@ export const ControlledBounds: Story = () => {
   return (
     <>
       <DateInput
-        controlledValue={value}
+        value={value}
         label={`Value (${min} <= x <= ${max})`}
         minValue={min}
         maxValue={max}
@@ -129,7 +129,7 @@ export const ControlledBounds: Story = () => {
         containerStyles={{ margin: 25 }}
       />
       <DateInput
-        controlledValue={min}
+        value={min}
         maxValue={max}
         label="Min"
         onValueChange={(newValue) => {
@@ -138,7 +138,7 @@ export const ControlledBounds: Story = () => {
         containerStyles={{ margin: 25 }}
       />
       <DateInput
-        controlledValue={max}
+        value={max}
         minValue={min}
         label="Max"
         onValueChange={(newValue) => {

--- a/src/stories/widgets/DateRangeInput.stories.tsx
+++ b/src/stories/widgets/DateRangeInput.stories.tsx
@@ -26,7 +26,7 @@ const Template: Story<DateRangeInputProps> = (args) => {
 
 export const Basic = Template.bind({});
 Basic.args = {
-  defaultRange: { min: new Date('2001-01-01'), max: new Date('2001-01-31') },
+  range: { min: new Date('2001-01-01'), max: new Date('2001-01-31') },
 };
 
 export const Labelled = Template.bind({});
@@ -38,14 +38,14 @@ Labelled.args = {
 export const Bounded = Template.bind({});
 Bounded.args = {
   label: 'Bounded (2001-01-01 to 2001-12-31)',
-  defaultRange: { min: new Date('2001-01-01'), max: new Date('2001-01-31') },
+  range: { min: new Date('2001-01-01'), max: new Date('2001-01-31') },
   rangeBounds: { min: new Date('2001-01-01'), max: new Date('2001-12-31') },
 };
 
 export const FullyLabelled = Template.bind({});
 FullyLabelled.args = {
   label: 'Select a range between 2001-01-01 and 2001-12-31',
-  defaultRange: { min: new Date('2001-01-01'), max: new Date('2001-01-31') },
+  range: { min: new Date('2001-01-01'), max: new Date('2001-01-31') },
   rangeBounds: { min: new Date('2001-01-01'), max: new Date('2001-12-31') },
   lowerLabel: 'Lower bound',
   upperLabel: 'Upper bound',

--- a/src/stories/widgets/NumberInput.stories.tsx
+++ b/src/stories/widgets/NumberInput.stories.tsx
@@ -25,7 +25,7 @@ const Template: Story<NumberInputProps> = (args) => {
 
 export const Basic = Template.bind({});
 Basic.args = {
-  defaultValue: 42,
+  value: 42,
 };
 
 export const Labelled = Template.bind({});
@@ -56,7 +56,7 @@ Bounded.args = {
 
 export const BoundedInitialized = Template.bind({});
 BoundedInitialized.args = {
-  defaultValue: 3,
+  value: 3,
   label: '0 <= x <= 5',
   minValue: 0,
   maxValue: 5,
@@ -67,7 +67,7 @@ const ControlledTemplate: Story<NumberInputProps> = (args) => {
   return (
     <NumberInput
       {...args}
-      controlledValue={value}
+      value={value}
       onValueChange={(newValue) => {
         console.log(`new value = ${newValue}`);
         setValue(newValue as number);
@@ -95,7 +95,7 @@ export const ControlledLinkedPair: Story = () => {
   return (
     <>
       <NumberInput
-        controlledValue={linkedValue}
+        value={linkedValue}
         label="A"
         onValueChange={(newValue) => {
           console.log(`A new value = ${newValue}`);
@@ -104,7 +104,7 @@ export const ControlledLinkedPair: Story = () => {
         containerStyles={{ margin: 25 }}
       />
       <NumberInput
-        controlledValue={linkedValue}
+        value={linkedValue}
         label="B"
         onValueChange={(newValue) => {
           console.log(`B new value = ${newValue}`);
@@ -124,7 +124,7 @@ export const ControlledBounds: Story = () => {
   return (
     <>
       <NumberInput
-        controlledValue={value}
+        value={value}
         label={`Value (${min} <= x <= ${max})`}
         minValue={min}
         maxValue={max}
@@ -137,7 +137,7 @@ export const ControlledBounds: Story = () => {
         containerStyles={{ margin: 25 }}
       />
       <NumberInput
-        controlledValue={min}
+        value={min}
         maxValue={max}
         label="Min"
         onValueChange={(newValue) => {
@@ -146,7 +146,7 @@ export const ControlledBounds: Story = () => {
         containerStyles={{ margin: 25 }}
       />
       <NumberInput
-        controlledValue={max}
+        value={max}
         minValue={min}
         label="Max"
         onValueChange={(newValue) => {

--- a/src/stories/widgets/NumberRangeInput.stories.tsx
+++ b/src/stories/widgets/NumberRangeInput.stories.tsx
@@ -26,7 +26,7 @@ const Template: Story<NumberRangeInputProps> = (args) => {
 
 export const Basic = Template.bind({});
 Basic.args = {
-  defaultRange: { min: 1, max: 5 },
+  range: { min: 1, max: 5 },
 };
 
 export const Labelled = Template.bind({});
@@ -38,14 +38,14 @@ Labelled.args = {
 export const Bounded = Template.bind({});
 Bounded.args = {
   label: 'Bounded (0 to 10)',
-  defaultRange: { min: 1, max: 9 },
+  range: { min: 1, max: 9 },
   rangeBounds: { min: 0, max: 10 },
 };
 
 export const FullyLabelled = Template.bind({});
 FullyLabelled.args = {
   label: 'Select a range between 0 and 10',
-  defaultRange: { min: 1, max: 9 },
+  range: { min: 1, max: 9 },
   rangeBounds: { min: 0, max: 10 },
   lowerLabel: 'Lower bound',
   upperLabel: 'Upper bound',


### PR DESCRIPTION
Input widgets had the ability to be controlled (state managed externally) *or* uncontrolled (state managed internally). This is tricky to get right, and we don't have an immediate need for uncontrolled behavior, so this PR removes that feature.

Additionally, `HistogramControls` no longer requires `selectedRangeBounds` to display the range selection widget. This gives the user a little more flexibility in drawing a selection. The selection is still "snapped" to the left-edge of the left-most selected bin, and the right-edge of the right-most selected bin.