### PR TITLE
Small histogram range selection bug fix

### DIFF
--- a/src/plots/Histogram.tsx
+++ b/src/plots/Histogram.tsx
@@ -194,8 +194,8 @@ export default function Histogram({
         const [min, max] = val1 > val2 ? [val2, val1] : [val1, val2];
         // TO DO: think about time zones?
         onSelectedRangeChange({
-          min: data.valueType === 'number' ? min : new Date(min),
-          max: data.valueType === 'number' ? max : new Date(max),
+          min: data.valueType === 'date' ? new Date(min) : min,
+          max: data.valueType === 'date' ? new Date(max) : max,
         } as NumberOrDateRange);
       }
     },


### PR DESCRIPTION
data.valueType can be undefined which wasn't being handled properly.

For the attention of @moontrip who will find this relevant to https://github.com/VEuPathDB/web-components/issues/66 