### PR TITLE
Widget/popover button

### DIFF
--- a/src/components/widgets/PopoverButton.tsx
+++ b/src/components/widgets/PopoverButton.tsx
@@ -1,0 +1,59 @@
+import React, { ReactNode, useState } from 'react';
+import { Button, Icon, Popover } from '@material-ui/core';
+
+export interface PopoverButtonProps {
+  /** Contents of the menu when opened */
+  children: ReactNode;
+  /** Contents of button */
+  label: ReactNode;
+}
+
+/**
+ * Renders a button that display `children` in a popover widget.
+ */
+export default function PopoverButton(props: PopoverButtonProps) {
+  const { children, label } = props;
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const menu = (
+    <Popover
+      id="dropdown"
+      open={Boolean(anchorEl)}
+      onClose={() => setAnchorEl(null)}
+      anchorEl={anchorEl}
+      anchorOrigin={{
+        vertical: 'bottom',
+        horizontal: 'left',
+      }}
+      transformOrigin={{
+        vertical: 'top',
+        horizontal: 'left',
+      }}
+      keepMounted
+    >
+      {children}
+    </Popover>
+  );
+
+  const button = (
+    <Button
+      aria-label="account of current user"
+      aria-controls="dropdown"
+      aria-haspopup="true"
+      color="default"
+      variant="contained"
+      onClick={(event) => {
+        setAnchorEl(event.currentTarget);
+      }}
+      endIcon={<Icon className="fa fa-caret-down" />}
+    >
+      {label}
+    </Button>
+  );
+
+  return (
+    <>
+      {button}
+      {menu}
+    </>
+  );
+}

--- a/src/stories/widgets/PopoverButton.stories.tsx
+++ b/src/stories/widgets/PopoverButton.stories.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
-import { Story, Meta } from '@storybook/react/types-6-0';
+import { Meta } from '@storybook/react/types-6-0';
 
 import PopoverButton from '../../components/widgets/PopoverButton';
-import { Typography } from '@material-ui/core';
 
 export default {
   title: 'Widgets/PopoverButton',

--- a/src/stories/widgets/PopoverButton.stories.tsx
+++ b/src/stories/widgets/PopoverButton.stories.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import { Story, Meta } from '@storybook/react/types-6-0';
+
+import PopoverButton from '../../components/widgets/PopoverButton';
+import { Typography } from '@material-ui/core';
+
+export default {
+  title: 'Widgets/PopoverButton',
+  component: PopoverButton,
+} as Meta;
+
+export const Basic = () => (
+  <PopoverButton label={<em>Open for details</em>}>
+    <div style={{ padding: '1em' }}>Some details that appear in a popover</div>
+  </PopoverButton>
+);
+
+export const Selector = () => {
+  const [option, setOption] = useState<string | null>(null);
+  const handleChange = (event: React.FormEvent<HTMLInputElement>) => {
+    setOption(event.currentTarget.value);
+  };
+  const label = option ? `Option ${option} selected` : 'Choose an option';
+  return (
+    <PopoverButton label={label}>
+      <div style={{ padding: '1em' }}>
+        {['A', 'B', 'C', 'D', 'E'].map((value) => (
+          <div key={value}>
+            <label>
+              <input
+                type="radio"
+                value={value}
+                checked={option === value}
+                onChange={handleChange}
+              />{' '}
+              Option {value}
+            </label>
+          </div>
+        ))}
+      </div>
+    </PopoverButton>
+  );
+};


### PR DESCRIPTION
This PR introduces a `PopoverButton` widget. This widget renders a button which, when clicked, displays a Popover element. The Popover element can contain any arbitrary content: tooltip-style text, a select-style menu, etc.