### PR TITLE
[issue-66] an approach for adjusting selected range

### DIFF
--- a/src/components/plotControls/HistogramControls.tsx
+++ b/src/components/plotControls/HistogramControls.tsx
@@ -225,6 +225,9 @@ export default function HistogramControls({
           valueType !== undefined && valueType === 'date' ? (
             <DateRangeInput
               label="Selected Range"
+              // need to set lowerLabel and upperLabel for handleOnChange (onChange)
+              lowerLabel="selectedRangeMin"
+              upperLabel="selectedRangeMax"
               rangeBounds={selectedRangeBounds as DateRange}
               range={selectedRange as DateRange}
               onRangeChange={onSelectedRangeChange}
@@ -232,6 +235,9 @@ export default function HistogramControls({
           ) : (
             <NumberRangeInput
               label="Selected Range"
+              // need to set lowerLabel and upperLabel for handleOnChange (onChange)
+              lowerLabel="selectedRangeMin"
+              upperLabel="selectedRangeMax"
               rangeBounds={selectedRangeBounds as NumberRange}
               range={selectedRange as NumberRange}
               onRangeChange={onSelectedRangeChange}

--- a/src/components/widgets/NumberAndDateInputs.tsx
+++ b/src/components/widgets/NumberAndDateInputs.tsx
@@ -18,6 +18,8 @@ type BaseProps<M extends NumberOrDate> = {
   label?: string;
   /** Additional styles for component container. Optional. */
   containerStyles?: React.CSSProperties;
+  // make prop for onChange property - needed to control user inputs & histogram
+  handleOnChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 };
 
 export type NumberInputProps = BaseProps<number>;
@@ -53,6 +55,8 @@ function BaseInput({
   label,
   valueType,
   containerStyles,
+  // add handleOnChange prop
+  handleOnChange,
 }: BaseInputProps) {
   const [focused, setFocused] = useState(false);
   const [errorState, setErrorState] = useState({
@@ -94,19 +98,9 @@ function BaseInput({
     if (newValue != null) onValueChange(newValue);
   }, [minValue, maxValue]);
 
-  const handleChange = (event: any) => {
-    if (event.target.value.length > 0) {
-      const newValue = boundsCheckedValue(
-        valueType === 'number'
-          ? Number(event.target.value)
-          : new Date(event.target.value)
-      );
-      if (newValue !== undefined) onValueChange(newValue);
-    } else {
-      // allows user to clear the input box
-      onValueChange(undefined);
-    }
-  };
+  // for conveniently editing, select all when focusing on an input field,
+  const handleFocus = (event: React.FocusEvent<HTMLInputElement>) =>
+    event.target.select();
 
   return (
     <div
@@ -122,9 +116,14 @@ function BaseInput({
               ? value
               : (value as Date)?.toISOString().substr(0, 10)
           }
+          // add name property for distinguishing what is changed (min or max)
+          name={label}
+          // add onFocus for conveniently editing the input field value
+          onFocus={handleFocus}
           type={valueType}
           variant="outlined"
-          onChange={handleChange}
+          // onChange to be props from parent, NumberAndDateRangeInputs component
+          onChange={handleOnChange}
           {...errorState}
         />
       </div>

--- a/src/components/widgets/NumberAndDateRangeInputs.tsx
+++ b/src/components/widgets/NumberAndDateRangeInputs.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 
 import { Typography } from '@material-ui/core';
 import { DARK_GRAY, MEDIUM_GRAY } from '../../constants/colors';
@@ -65,6 +65,48 @@ function BaseInput({
   const [focused, setFocused] = useState(false);
 
   const { min, max } = range ?? {};
+
+  // this will be sent to NumberAndDateInputs component as a prop to control user inputs
+  const handleOnChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      if (event.target.value.length > 0) {
+        const newValue =
+          valueType === 'number'
+            ? Number(event.target.value)
+            : new Date(event.target.value);
+        /**
+         * event.target.name (name prop at input form) is either lowerLabel or upperLabel
+         * they should be defined as props at the parent, HistogramControl,
+         *   to distinguish this Selected Range from other range widget
+         * here, they are named as selectedRangeMin and selectedRangeMax, respectively
+         */
+        if (
+          newValue !== undefined &&
+          event.target.name === 'selectedRangeMin'
+        ) {
+          onRangeChange
+            ? valueType === 'number'
+              ? onRangeChange({ min: newValue, max } as NumberRange)
+              : onRangeChange({ min: newValue, max } as DateRange)
+            : null;
+        } else if (
+          newValue !== undefined &&
+          event.target.name === 'selectedRangeMax'
+        ) {
+          onRangeChange
+            ? valueType === 'number'
+              ? onRangeChange({ min, max: newValue } as NumberRange)
+              : onRangeChange({ min, max: newValue } as DateRange)
+            : null;
+        }
+      } else {
+        // allows user to clear the input box - no need to have?
+        // onRangeChange? onRangeChange({ min, max } as NumberRange) : null;
+      }
+    },
+    [onRangeChange]
+  );
+
   return (
     <div
       style={{ ...containerStyles }}
@@ -86,6 +128,8 @@ function BaseInput({
             minValue={rangeBounds?.min as number}
             maxValue={(max ?? rangeBounds?.max) as number}
             label={lowerLabel}
+            // add a new prop
+            handleOnChange={handleOnChange}
             onValueChange={(newValue) => {
               if (newValue !== undefined && onRangeChange)
                 onRangeChange({ min: newValue, max } as NumberRange);
@@ -97,6 +141,8 @@ function BaseInput({
             minValue={rangeBounds?.min as Date}
             maxValue={(max ?? rangeBounds?.max) as Date}
             label={lowerLabel}
+            // add a new prop
+            handleOnChange={handleOnChange}
             onValueChange={(newValue) => {
               if (newValue !== undefined && onRangeChange)
                 onRangeChange({ min: newValue, max } as DateRange);
@@ -120,6 +166,8 @@ function BaseInput({
             minValue={(min ?? rangeBounds?.min) as number}
             maxValue={rangeBounds?.max as number}
             label={upperLabel}
+            // add a new prop
+            handleOnChange={handleOnChange}
             onValueChange={(newValue) => {
               if (newValue !== undefined && onRangeChange)
                 onRangeChange({ min, max: newValue } as NumberRange);
@@ -131,6 +179,8 @@ function BaseInput({
             minValue={(min ?? rangeBounds?.min) as Date}
             maxValue={rangeBounds?.max as Date}
             label={upperLabel}
+            // add a new prop
+            handleOnChange={handleOnChange}
             onValueChange={(newValue) => {
               if (newValue !== undefined && onRangeChange)
                 onRangeChange({ min, max: newValue } as DateRange);


### PR DESCRIPTION
@dmfalke and @bobular Since #99  may solve this issue, #66, my work may not be needed anymore. Thus, this PR just intends to share what my approach was. There are couple of more things to do for completeness but I just stopped doing further owing to #99 . So, please just take a look at it and close this PR as this may not be worthwhile :)

Simply put, my approach was to move onChange function (handleChange) at NumberAndDateInputs component to the parent component, NumberAndDateRangeInputs (named, handleOnChange). This resolved the issue that selected range inputs could not be changed after mouse selection. One of disadvantages in this approach is that additional parameters/props are needed to distinguish min from max (or vice versa) as the onChange function is out of NumberAndDateInputs component: so, I used name property (for TextField/Input) and upperLabel & lowerLabel props to set the different value of the name property for min and max inputs respectively