### PR TITLE
making Scatter plot controls

### DIFF
--- a/src/components/plotControls/ScatterplotControls.tsx
+++ b/src/components/plotControls/ScatterplotControls.tsx
@@ -1,0 +1,122 @@
+import React, { useMemo } from 'react';
+import useDimensions from 'react-cool-dimensions';
+
+// Definitions
+import { LIGHT_BLUE, LIGHT_GRAY } from '../../constants/colors';
+import { ErrorManagement } from '../../types/general';
+import ControlsHeader from '../typography/ControlsHeader';
+
+// Local Components
+import ButtonGroup from '../widgets/ButtonGroup';
+import Notification from '../widgets/Notification';
+
+/**
+ * Props for scatterplot controls.
+ *
+ * The presence or absence of an optional callback will
+ * determine if that control is displayed.
+ */
+export type ScatterplotControlsProps = {
+  /** Label for control panel. Optional. */
+  label?: string;
+  /** Additional styles for controls container. Optional */
+  containerStyles?: React.CSSProperties;
+  /** Color to use as an accent in the control panel. Will accept any
+   * valid CSS color definition. Defaults to LIGHT_BLUE */
+  accentColor?: string;
+  /** Attributes and methdods for error management. */
+  errorManagement: ErrorManagement;
+  /** Scatterplot: valueSpec */
+  valueSpec?: string;
+  /** Scatterplot: valueSpec */
+  onValueSpecChange?: (valueSpec: string) => void;
+};
+
+/**
+ * A scatterplot controls panel.
+ *
+ * If you prefer a different layout or composition, you can
+ * contruct you own control panel by using the various
+ * widgets contained here.
+ */
+export default function ScatterplotControls({
+  label,
+  accentColor = LIGHT_BLUE,
+  errorManagement,
+  containerStyles,
+  // valueSpec
+  valueSpec,
+  onValueSpecChange,
+}: ScatterplotControlsProps) {
+  const { ref, width } = useDimensions<HTMLDivElement>();
+
+  const errorStacks = useMemo(() => {
+    return errorManagement.errors.reduce<
+      Array<{ error: Error; occurences: number }>
+    >((accumulatedValue, currentValue) => {
+      const existingErrorStack = accumulatedValue.find(
+        (stack) => stack.error.message === currentValue.message
+      );
+
+      if (existingErrorStack) {
+        existingErrorStack.occurences++;
+        return [...accumulatedValue];
+      } else {
+        return [...accumulatedValue, { error: currentValue, occurences: 1 }];
+      }
+    }, []);
+  }, [errorManagement.errors]);
+
+  return (
+    <div
+      ref={ref}
+      style={{
+        borderStyle: 'solid',
+        borderWidth: '0.125em',
+        borderColor: LIGHT_GRAY,
+        borderRadius: '0.6125em',
+        padding: '0.9375em',
+        minWidth: '11em',
+        width: 1000,
+        ...containerStyles,
+      }}
+    >
+      <div
+        style={{ display: 'flex', flexWrap: 'wrap', paddingTop: '0.3125em' }}
+      >
+        {valueSpec && onValueSpecChange && (
+          <ButtonGroup
+            label="Data"
+            options={[
+              'raw',
+              'smoothedMean',
+              'smoothedMeanWithRaw',
+              'bestFitLineWithRaw',
+            ]}
+            selectedOption={valueSpec}
+            // @ts-ignore
+            onOptionSelected={onValueSpecChange}
+          />
+        )}
+      </div>
+      {errorStacks.map(({ error, occurences }, index) => (
+        <Notification
+          title="Error"
+          key={index}
+          text={error.message}
+          color={accentColor}
+          occurences={occurences}
+          containerStyles={{ marginTop: '0.625em' }}
+          onAcknowledgement={() => errorManagement.removeError(error)}
+        />
+      ))}
+
+      {label && (
+        <ControlsHeader
+          text={label}
+          styleOverrides={{ paddingTop: '1.5625em', textAlign: 'right' }}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/stories/plotControls/ScatterplotControls.stories.tsx
+++ b/src/stories/plotControls/ScatterplotControls.stories.tsx
@@ -1,0 +1,33 @@
+import { Story, Meta } from '@storybook/react/types-6-0';
+
+import ScatterplotControls from '../../components/plotControls/ScatterplotControls';
+import usePlotControls, {
+  usePlotControlsParams,
+} from '../../hooks/usePlotControls';
+
+export default {
+  title: 'Plot Controls/Scatterplot',
+  component: ScatterplotControls,
+} as Meta;
+
+export const BasicControls: Story<usePlotControlsParams<any>> = (args) => {
+  const controls = usePlotControls<any>({
+    data: args.data,
+    scatterplot: args.scatterplot,
+  });
+
+  return (
+    <ScatterplotControls
+      label="Scatter Plot Control Panel"
+      {...controls}
+      {...controls.scatterplot}
+    />
+  );
+};
+
+BasicControls.args = {
+  data: { series: [{ name: 'dummy data', bins: [] }] },
+  scatterplot: {
+    valueSpec: 'raw',
+  },
+};


### PR DESCRIPTION
Implemented scatter plot controls that would be used at scatter plot viz to change data response (and plot). A story is made to test and usePlotControls hook is changed/utilized for that purpose. With the addition of of the "bestFitLineWithRaw" response, I feel that the "SmoothedMean" may be no longer required, but it is included anyway. A screenshot is attached here.

![scatterplotcontrols1](https://user-images.githubusercontent.com/12802305/117870365-03811200-b26a-11eb-8a12-234ed5f164b4.png)
