### PR TITLE
Potential new plot control approach

### DIFF
--- a/src/components/plotControls/AxisControls.tsx
+++ b/src/components/plotControls/AxisControls.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import {
+  NumberOrDateRange,
+  NumberRange,
+  DateRange,
+} from '../../../lib/types/general';
+import LabelledGroup from '../widgets/LabelledGroup';
+import {
+  NumberRangeInput,
+  DateRangeInput,
+} from '../widgets/NumberAndDateRangeInputs';
+import Switch from '../widgets/Switch';
+import Button from '../widgets/Button';
+
+export type AxisControlsProps = {
+  /** Label for control panel. Optional. */
+  label?: string;
+  /** Type of variable 'number' or 'date' */
+  valueType?: 'number' | 'date';
+  /** Whether or not to show axis log scale. */
+  logScale?: boolean;
+  /** Action to take on axis log scale change. */
+  toggleLogScale?: (logScale: boolean) => void;
+  /** Whether or not to set axis min/max range. */
+  axisRange?: NumberOrDateRange;
+  /** Action to take on axis min/max range change. */
+  onAxisRangeChange?: (newRange?: NumberOrDateRange) => void;
+  /** Action to take when resetting this axis */
+  onAxisReset?: () => void;
+  /** Additional styles for controls container. Optional */
+  containerStyles?: React.CSSProperties;
+};
+
+export default function AxisControls({
+  label,
+  valueType = 'number',
+  logScale,
+  toggleLogScale,
+  axisRange,
+  onAxisRangeChange,
+  onAxisReset,
+  containerStyles,
+}: AxisControlsProps) {
+  return (
+    <LabelledGroup label={label} containerStyles={containerStyles}>
+      {toggleLogScale && logScale !== undefined && (
+        <Switch
+          label="Log scale:"
+          state={logScale}
+          // The stinky use of `any` here comes from
+          // an incomplete type definition in the
+          // material UI library.
+          onStateChange={(event: any) => toggleLogScale(event.target.checked)}
+          containerStyles={{ paddingBottom: '0.3125em' }}
+        />
+      )}
+      {onAxisRangeChange &&
+        (valueType !== undefined && valueType === 'date' ? (
+          <DateRangeInput
+            label="Range:"
+            range={axisRange as DateRange}
+            onRangeChange={onAxisRangeChange}
+            allowPartialRange={false}
+          />
+        ) : (
+          <NumberRangeInput
+            label="Range:"
+            range={axisRange as NumberRange}
+            onRangeChange={onAxisRangeChange}
+            allowPartialRange={false}
+          />
+        ))}
+
+      {onAxisReset && (
+        <Button
+          type={'solid'}
+          text={'Reset to defaults'}
+          onClick={onAxisReset}
+          containerStyles={{
+            paddingTop: '1.0em',
+            width: '100%',
+          }}
+        />
+      )}
+    </LabelledGroup>
+  );
+}

--- a/src/plots/Histogram.tsx
+++ b/src/plots/Histogram.tsx
@@ -80,6 +80,9 @@ export interface HistogramProps {
   selectedRangeBounds?: NumberOrDateRange; // TO DO: handle DateRange too
   /** Relevant to range selection - flag to indicate if the data is zoomed in. Default false. */
   isZoomed?: boolean;
+
+  /** TEMPORARY: Added for simpler demo of SuperScatter / AxisControls */
+  independentAxisRange?: NumberOrDateRange;
 }
 
 /** A Plot.ly based histogram component. */
@@ -109,6 +112,7 @@ export default function Histogram({
   onSelectedRangeChange = () => {},
   selectedRangeBounds,
   isZoomed = false,
+  independentAxisRange,
 }: HistogramProps) {
   const [revision, setRevision] = useState(0);
 
@@ -342,7 +346,9 @@ export default function Histogram({
       },
     },
     color: textColor,
-    range: [minBinStart, maxBinEnd],
+    range: independentAxisRange
+      ? [independentAxisRange.min, independentAxisRange.max]
+      : [minBinStart, maxBinEnd],
     fixedrange: true,
   };
   const dependentAxisLayout: Layout['yaxis'] | Layout['xaxis'] = {

--- a/src/plots/ScatterAndLinePlotGeneral.tsx
+++ b/src/plots/ScatterAndLinePlotGeneral.tsx
@@ -8,7 +8,7 @@ type PlotDataKey = keyof PlotData;
 
 // change interface a bit more: this could avoid error on data type
 export interface ScatterplotProps<T extends keyof PlotData> extends PlotProps {
-  data: Pick<PlotData, T>[];
+  data: any; // Pick<PlotData, T>[];
   xLabel?: string;
   yLabel?: string;
   plotTitle?: string;

--- a/src/stories/plots/SuperScatter.stories.tsx
+++ b/src/stories/plots/SuperScatter.stories.tsx
@@ -1,7 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import ScatterAndLinePlotGeneral from '../../plots/ScatterAndLinePlotGeneral';
 import Histogram from '../../plots/Histogram';
-import { HistogramData, HistogramBin } from '../../types/plots';
+import AxisControls from '../../components/plotControls/AxisControls';
+
+import { HistogramData } from '../../types/plots';
+import { NumberRange } from '../../types/general';
+import { NumberOrDateRange } from '../../../lib/types/general';
 
 export default {
   title: 'Plots/SuperScatter',
@@ -99,7 +103,10 @@ export const SuperScatter = () => {
     ],
   };
 
-  const [xMin, xMax, yMin, yMax] = [0, 10, 0, 10];
+  const defaultXRange = { min: 0, max: 10 };
+  const defaultYRange = { min: 0, max: 10 };
+  const [xRange, setXRange] = useState<NumberRange>(defaultXRange);
+  const [yRange, setYRange] = useState<NumberRange>(defaultYRange);
 
   return (
     <div
@@ -109,22 +116,45 @@ export const SuperScatter = () => {
         <Histogram
           data={histoDataX}
           width={mainPlotWidth}
-          height={mainPlotHeight / 2}
+          height={mainPlotHeight * 0.75}
           orientation="vertical"
           barLayout="group"
           displayLegend={false}
           displayLibraryControls={false}
+          independentAxisRange={xRange}
         />
       </div>
-      <div style={{ flex: '1 1 45%', border: '1px solid pink' }}></div>
+      <div style={{ flex: '1 1 45%', border: '1px solid pink' }}>
+        <AxisControls
+          label="x axis"
+          axisRange={xRange}
+          onAxisRangeChange={(newRange?: NumberOrDateRange) => {
+            setXRange(newRange as NumberRange);
+          }}
+          onAxisReset={() => {
+            setXRange(defaultXRange);
+          }}
+        />
+
+        <AxisControls
+          label="y axis"
+          axisRange={yRange}
+          onAxisRangeChange={(newRange?: NumberOrDateRange) => {
+            setYRange(newRange as NumberRange);
+          }}
+          onAxisReset={() => {
+            setXRange(defaultYRange);
+          }}
+        />
+      </div>
       <div style={{ flex: '1 1 45%', border: '1px solid green' }}>
         <ScatterAndLinePlotGeneral
           data={scatterData}
           xLabel={xLabel}
           yLabel={yLabel}
           plotTitle={plotTitle}
-          xRange={[xMin, xMax]}
-          yRange={[yMin, yMax]}
+          xRange={[xRange.min, xRange.max]}
+          yRange={[yRange.min, yRange.max]}
           width={mainPlotWidth}
           height={mainPlotHeight}
           staticPlot={true}
@@ -135,12 +165,13 @@ export const SuperScatter = () => {
       <div style={{ flex: '1 1 45%', border: '1px solid blue' }}>
         <Histogram
           data={histoDataY}
-          width={mainPlotWidth / 2}
+          width={mainPlotWidth * 0.75}
           height={mainPlotHeight}
           orientation="horizontal"
           barLayout="group"
           displayLegend={false}
           displayLibraryControls={false}
+          independentAxisRange={yRange}
         />
       </div>
     </div>

--- a/src/stories/plots/SuperScatter.stories.tsx
+++ b/src/stories/plots/SuperScatter.stories.tsx
@@ -1,0 +1,175 @@
+import React from 'react';
+import ScatterAndLinePlotGeneral from '../../plots/ScatterAndLinePlotGeneral';
+import Histogram from '../../plots/Histogram';
+import { HistogramData, HistogramBin } from '../../types/plots';
+
+export default {
+  title: 'Plots/SuperScatter',
+  component: ScatterAndLinePlotGeneral,
+  parameters: {},
+};
+
+export const SuperScatter = () => {
+  const mainPlotWidth = 450;
+  const mainPlotHeight = 450;
+  const xLabel = 'A variable';
+  const yLabel = 'Another variable';
+  const plotTitle = 'Scatter component';
+
+  const scatterData = [
+    // just one series
+    {
+      x: [
+        4.6,
+        6.8,
+        7.3,
+        7.4,
+        0.5,
+        0.7,
+        0.8,
+        9.7,
+        3.3,
+        3.9,
+        4.0,
+        2.6,
+        6.7,
+        6.3,
+        4.2,
+        1.2,
+        6.7,
+        5.0,
+        4.9,
+        6.7,
+      ],
+      y: [
+        1.8,
+        0.1,
+        1.0,
+        6.9,
+        7.7,
+        3.2,
+        1.4,
+        8.7,
+        7.9,
+        8.7,
+        5.5,
+        9.1,
+        4.5,
+        4.1,
+        8.6,
+        5.1,
+        3.6,
+        8.9,
+        4.7,
+        1.1,
+      ],
+      name: 'Noise',
+      mode: 'markers',
+      type: 'scatter',
+    },
+  ];
+
+  const histoDataX: HistogramData = {
+    series: [
+      {
+        name: 'x var',
+        bins: [
+          { binStart: 0, binEnd: 2, binLabel: '0-2', count: 4 },
+          { binStart: 2, binEnd: 4, binLabel: '2-4', count: 4 },
+          { binStart: 4, binEnd: 6, binLabel: '4-6', count: 4 },
+          { binStart: 6, binEnd: 8, binLabel: '6-8', count: 7 },
+          { binStart: 8, binEnd: 10, binLabel: '8-10', count: 1 },
+        ],
+      },
+    ],
+  };
+
+  const histoDataY: HistogramData = {
+    series: [
+      {
+        name: 'y var',
+        bins: [
+          { binStart: 0, binEnd: 2, binLabel: '0-2', count: 5 },
+          { binStart: 2, binEnd: 4, binLabel: '2-4', count: 2 },
+          { binStart: 4, binEnd: 6, binLabel: '4-6', count: 5 },
+          { binStart: 6, binEnd: 8, binLabel: '6-8', count: 3 },
+          { binStart: 8, binEnd: 10, binLabel: '8-10', count: 5 },
+        ],
+      },
+    ],
+  };
+
+  const [xMin, xMax, yMin, yMax] = [0, 10, 0, 10];
+
+  return (
+    <div
+      style={{ display: 'flex', flexWrap: 'wrap', width: mainPlotWidth * 2 }}
+    >
+      <div style={{ flex: '1 1 45%', border: '1px solid black' }}>
+        <Histogram
+          data={histoDataX}
+          width={mainPlotWidth}
+          height={mainPlotHeight / 2}
+          orientation="vertical"
+          barLayout="group"
+          displayLegend={false}
+          displayLibraryControls={false}
+        />
+      </div>
+      <div style={{ flex: '1 1 45%', border: '1px solid pink' }}></div>
+      <div style={{ flex: '1 1 45%', border: '1px solid green' }}>
+        <ScatterAndLinePlotGeneral
+          data={scatterData}
+          xLabel={xLabel}
+          yLabel={yLabel}
+          plotTitle={plotTitle}
+          xRange={[xMin, xMax]}
+          yRange={[yMin, yMax]}
+          width={mainPlotWidth}
+          height={mainPlotHeight}
+          staticPlot={true}
+          displayLegend={false}
+          displayLibraryControls={false}
+        />
+      </div>
+      <div style={{ flex: '1 1 45%', border: '1px solid blue' }}>
+        <Histogram
+          data={histoDataY}
+          width={mainPlotWidth / 2}
+          height={mainPlotHeight}
+          orientation="horizontal"
+          barLayout="group"
+          displayLegend={false}
+          displayLibraryControls={false}
+        />
+      </div>
+    </div>
+  );
+};
+
+function getMinDate(dates: Date[]) {
+  return new Date(Math.min(...dates.map(Number)));
+}
+
+function getMaxDate(dates: Date[]) {
+  return new Date(Math.max(...dates.map(Number)));
+}
+
+function getBounds<T extends number | Date>(
+  values: T[],
+  standardErrors: T[]
+): {
+  yUpperValues: T[];
+  yLowerValues: T[];
+} {
+  const yUpperValues = values.map((value, idx) => {
+    const tmp = Number(value) + 2 * Number(standardErrors[idx]);
+    return value instanceof Date ? (new Date(tmp) as T) : (tmp as T);
+  });
+  const yLowerValues = values.map((value, idx) => {
+    const tmp = Number(value) - 2 * Number(standardErrors[idx]);
+    return value instanceof Date ? (new Date(tmp) as T) : (tmp as T);
+  });
+
+  return { yUpperValues, yLowerValues };
+}

--- a/src/stories/plots/SuperScatter.stories.tsx
+++ b/src/stories/plots/SuperScatter.stories.tsx
@@ -112,7 +112,7 @@ export const SuperScatter = () => {
     <div
       style={{ display: 'flex', flexWrap: 'wrap', width: mainPlotWidth * 2 }}
     >
-      <div style={{ flex: '1 1 45%', border: '1px solid black' }}>
+      <div style={{ flex: '1 1 45%' }}>
         <Histogram
           data={histoDataX}
           width={mainPlotWidth}
@@ -124,7 +124,7 @@ export const SuperScatter = () => {
           independentAxisRange={xRange}
         />
       </div>
-      <div style={{ flex: '1 1 45%', border: '1px solid pink' }}>
+      <div style={{ flex: '1 1 45%' }}>
         <AxisControls
           label="x axis"
           axisRange={xRange}
@@ -143,11 +143,11 @@ export const SuperScatter = () => {
             setYRange(newRange as NumberRange);
           }}
           onAxisReset={() => {
-            setXRange(defaultYRange);
+            setYRange(defaultYRange);
           }}
         />
       </div>
-      <div style={{ flex: '1 1 45%', border: '1px solid green' }}>
+      <div style={{ flex: '1 1 45%' }}>
         <ScatterAndLinePlotGeneral
           data={scatterData}
           xLabel={xLabel}
@@ -162,7 +162,7 @@ export const SuperScatter = () => {
           displayLibraryControls={false}
         />
       </div>
-      <div style={{ flex: '1 1 45%', border: '1px solid blue' }}>
+      <div style={{ flex: '1 1 45%' }}>
         <Histogram
           data={histoDataY}
           width={mainPlotWidth * 0.75}
@@ -177,30 +177,3 @@ export const SuperScatter = () => {
     </div>
   );
 };
-
-function getMinDate(dates: Date[]) {
-  return new Date(Math.min(...dates.map(Number)));
-}
-
-function getMaxDate(dates: Date[]) {
-  return new Date(Math.max(...dates.map(Number)));
-}
-
-function getBounds<T extends number | Date>(
-  values: T[],
-  standardErrors: T[]
-): {
-  yUpperValues: T[];
-  yLowerValues: T[];
-} {
-  const yUpperValues = values.map((value, idx) => {
-    const tmp = Number(value) + 2 * Number(standardErrors[idx]);
-    return value instanceof Date ? (new Date(tmp) as T) : (tmp as T);
-  });
-  const yLowerValues = values.map((value, idx) => {
-    const tmp = Number(value) - 2 * Number(standardErrors[idx]);
-    return value instanceof Date ? (new Date(tmp) as T) : (tmp as T);
-  });
-
-  return { yUpperValues, yLowerValues };
-}


### PR DESCRIPTION
The `Plots -> Super Scatter` story in SuperScatter.stories.tsx has a scatterplot with a histogram for each variable.

There's a new `AxisControls` component that can handle
- log scale on/off
- axis range (for zooming)
- reset axis

This is used twice. (I **temporarily** added a trivial client-side x-axis zooming to Histogram (independentAxisRange) just to avoid having to use any dynamic data generation.)

I imagine some other generic controls such as `MarkerControls`:
- opacity
- stacked or grouped
- relative or absolute
These apply to a whole plot and not a specific axis (that is potentially debatable)

Also `RangeSelectionControls` and `BinningControls`.

The idea is to avoid duplication wrt HistogramControls, BarplotControls, BoxplotControls, PieControls, etc, and be ready to handle more complex visualisations.

![image](https://user-images.githubusercontent.com/308639/119205999-d0245b80-ba91-11eb-9737-058fbc4ee643.png)
