### PR TITLE
new radio widget, stories, changes for controls

### DIFF
--- a/src/components/plotControls/XYPlotControls.tsx
+++ b/src/components/plotControls/XYPlotControls.tsx
@@ -38,7 +38,7 @@ export type XYPlotControlsProps = {
   /** button color: for now, supporting blue and red only - primary: blue; secondary: red */
   buttonColor?: 'primary' | 'secondary';
   /** margin of radio button group: string array for top, left, bottom, and left, e.g., ['10em', '0', '0', '10em'] */
-  setMargin?: string[];
+  margins?: string[];
 };
 
 /**
@@ -60,7 +60,7 @@ export default function XYPlotControls({
   labelPlacement,
   minWidth,
   buttonColor,
-  setMargin,
+  margins,
 }: XYPlotControlsProps) {
   const { ref, width } = useDimensions<HTMLDivElement>();
 
@@ -113,7 +113,7 @@ export default function XYPlotControls({
             labelPlacement={labelPlacement}
             minWidth={minWidth}
             buttonColor={buttonColor}
-            setMargin={setMargin}
+            margins={margins}
           />
         )}
       </div>

--- a/src/components/plotControls/XYPlotControls.tsx
+++ b/src/components/plotControls/XYPlotControls.tsx
@@ -4,14 +4,13 @@ import useDimensions from 'react-cool-dimensions';
 // Definitions
 import { LIGHT_BLUE, LIGHT_GRAY } from '../../constants/colors';
 import { ErrorManagement } from '../../types/general';
-import ControlsHeader from '../typography/ControlsHeader';
 
 // Local Components
-import ButtonGroup from '../widgets/ButtonGroup';
+import RadioButtonGroup from '../widgets/RadioButtonGroup';
 import Notification from '../widgets/Notification';
 
 /**
- * Props for scatterplot controls.
+ * Props for XYPlot controls.
  *
  * The presence or absence of an optional callback will
  * determine if that control is displayed.
@@ -24,16 +23,26 @@ export type XYPlotControlsProps = {
   /** Color to use as an accent in the control panel. Will accept any
    * valid CSS color definition. Defaults to LIGHT_BLUE */
   accentColor?: string;
-  /** Attributes and methdods for error management. */
+  /** Attributes and methods for error management. */
   errorManagement: ErrorManagement;
-  /** Scatterplot: valueSpec */
+  /** XYPlot: valueSpec */
   valueSpec?: string;
-  /** Scatterplot: valueSpec */
+  /** XYPlot: valueSpec */
   onValueSpecChange?: (valueSpec: string) => void;
+  /** How buttons are displayed. Vertical or Horizontal */
+  orientation?: 'vertical' | 'horizontal';
+  /** location of radio button label: start: label & button; end: button & label */
+  labelPlacement?: 'start' | 'end' | 'top' | 'bottom';
+  /** minimum width to set up equivalently spaced width per item */
+  minWidth?: number;
+  /** button color: for now, supporting blue and red only - primary: blue; secondary: red */
+  buttonColor?: 'primary' | 'secondary';
+  /** margin of radio button group: string array for top, left, bottom, and left, e.g., ['10em', '0', '0', '10em'] */
+  setMargin?: string[];
 };
 
 /**
- * A scatterplot controls panel.
+ * A XYPlot controls panel.
  *
  * If you prefer a different layout or composition, you can
  * contruct you own control panel by using the various
@@ -47,6 +56,11 @@ export default function XYPlotControls({
   // valueSpec
   valueSpec,
   onValueSpecChange,
+  orientation,
+  labelPlacement,
+  minWidth,
+  buttonColor,
+  setMargin,
 }: XYPlotControlsProps) {
   const { ref, width } = useDimensions<HTMLDivElement>();
 
@@ -82,12 +96,9 @@ export default function XYPlotControls({
         ...containerStyles,
       }}
     >
-      {/* <div
-        style={{ display: 'flex', flexWrap: 'wrap', paddingTop: '0.3125em' }}
-      > */}
       <div style={{ display: 'flex' }}>
         {valueSpec && onValueSpecChange && (
-          <ButtonGroup
+          <RadioButtonGroup
             label="Plot options"
             options={[
               'Raw',
@@ -98,6 +109,11 @@ export default function XYPlotControls({
             selectedOption={valueSpec}
             // @ts-ignore
             onOptionSelected={onValueSpecChange}
+            orientation={orientation}
+            labelPlacement={labelPlacement}
+            minWidth={minWidth}
+            buttonColor={buttonColor}
+            setMargin={setMargin}
           />
         )}
       </div>
@@ -112,13 +128,6 @@ export default function XYPlotControls({
           onAcknowledgement={() => errorManagement.removeError(error)}
         />
       ))}
-
-      {label && (
-        <ControlsHeader
-          text={label}
-          styleOverrides={{ paddingTop: '1.5625em', textAlign: 'right' }}
-        />
-      )}
     </div>
   );
 }

--- a/src/components/widgets/RadioButtonGroup.tsx
+++ b/src/components/widgets/RadioButtonGroup.tsx
@@ -27,7 +27,7 @@ export type RadioButtonGroupProps = {
   /** button color: for now, supporting blue and red only - primary: blue; secondary: red */
   buttonColor?: 'primary' | 'secondary';
   /** margin of radio button group: string array for top, left, bottom, and left, e.g., ['10em', '0', '0', '10em'] */
-  setMargin?: string[];
+  margins?: string[];
 };
 
 /**
@@ -44,16 +44,10 @@ export default function RadioButtonGroup({
   labelPlacement,
   minWidth,
   buttonColor,
-  setMargin,
+  margins,
 }: RadioButtonGroupProps) {
   // perhaps not using focused?
   // const [focused, setFocused] = useState(false);
-
-  //DKDK
-  console.log('selectedOption = ', selectedOption);
-  console.log('orientation = ', orientation);
-  console.log('buttonColor = ', buttonColor);
-  console.log('setMargin = ', setMargin);
 
   return (
     <div
@@ -61,10 +55,10 @@ export default function RadioButtonGroup({
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'flex-start',
-        marginTop: setMargin ? setMargin[0] : '',
-        marginRight: setMargin ? setMargin[1] : '',
-        marginBottom: setMargin ? setMargin[2] : '',
-        marginLeft: setMargin ? setMargin[3] : '',
+        marginTop: margins ? margins[0] : '',
+        marginRight: margins ? margins[1] : '',
+        marginBottom: margins ? margins[2] : '',
+        marginLeft: margins ? margins[3] : '',
         ...containerStyles,
       }}
       // perhaps not using focused?

--- a/src/components/widgets/RadioButtonGroup.tsx
+++ b/src/components/widgets/RadioButtonGroup.tsx
@@ -1,0 +1,115 @@
+// widget for radio button group
+import React, { useState } from 'react';
+import Radio from '@material-ui/core/Radio';
+import RadioGroup from '@material-ui/core/RadioGroup';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import FormControl from '@material-ui/core/FormControl';
+import { DARK_GRAY, MEDIUM_GRAY } from '../../constants/colors';
+import { Typography } from '@material-ui/core';
+
+export type RadioButtonGroupProps = {
+  /** Label for the widget. Optional. */
+  label?: string;
+  /** How buttons are displayed. Vertical or Horizontal */
+  orientation?: 'vertical' | 'horizontal';
+  /** Options that will be presented as buttons. */
+  options: Array<string>;
+  /** The currently selected option.  */
+  selectedOption: string;
+  /** Action to take when an option is selected by the user. */
+  onOptionSelected: (option: string) => void;
+  /** Additional widget container styles. Optional. */
+  containerStyles?: React.CSSProperties;
+  /** location of radio button label: start: label & button; end: button & label */
+  labelPlacement?: 'start' | 'end' | 'top' | 'bottom';
+  /** minimum width to set up equivalently spaced width per item */
+  minWidth?: number;
+  /** button color: for now, supporting blue and red only - primary: blue; secondary: red */
+  buttonColor?: 'primary' | 'secondary';
+  /** margin of radio button group: string array for top, left, bottom, and left, e.g., ['10em', '0', '0', '10em'] */
+  setMargin?: string[];
+};
+
+/**
+ * A simple group of radio buttons in which only a single
+ * radio button can be selected at any given time.
+ */
+export default function RadioButtonGroup({
+  label = undefined,
+  orientation = 'horizontal',
+  options,
+  selectedOption,
+  onOptionSelected,
+  containerStyles = {},
+  labelPlacement,
+  minWidth,
+  buttonColor,
+  setMargin,
+}: RadioButtonGroupProps) {
+  // perhaps not using focused?
+  // const [focused, setFocused] = useState(false);
+
+  //DKDK
+  console.log('selectedOption = ', selectedOption);
+  console.log('orientation = ', orientation);
+  console.log('buttonColor = ', buttonColor);
+  console.log('setMargin = ', setMargin);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'flex-start',
+        marginTop: setMargin ? setMargin[0] : '',
+        marginRight: setMargin ? setMargin[1] : '',
+        marginBottom: setMargin ? setMargin[2] : '',
+        marginLeft: setMargin ? setMargin[3] : '',
+        ...containerStyles,
+      }}
+      // perhaps not using focused?
+      // onMouseOver={() => setFocused(true)}
+      // onMouseOut={() => setFocused(false)}
+    >
+      {label && (
+        <Typography
+          variant="button"
+          // perhaps not using focused?
+          // style={{ color: focused ? DARK_GRAY : MEDIUM_GRAY }}
+          style={{ color: '#000000', fontWeight: 'bold' }}
+        >
+          {label}
+        </Typography>
+      )}
+      <FormControl style={{ width: '100%' }}>
+        <RadioGroup
+          value={selectedOption}
+          onChange={(event, value) => value && onOptionSelected(value)}
+          aria-label={`${label} control button group`}
+          row={orientation === 'horizontal' ? true : false}
+        >
+          {options.map((option, index) => (
+            <FormControlLabel
+              key={index}
+              value={option}
+              label={option}
+              labelPlacement={labelPlacement}
+              // primary: blue; secondary: red
+              control={<Radio color={buttonColor} />}
+              style={{
+                // padding: 5,
+                // paddingLeft: 7.5,
+                // paddingRight: 7.5,
+                fontSize: '0.75em',
+                fontWeight: 400,
+                textTransform: 'capitalize',
+                // justifyContent: 'start',
+                minWidth: minWidth,
+              }}
+            />
+          ))}
+        </RadioGroup>
+      </FormControl>
+    </div>
+  );
+}

--- a/src/hooks/usePlotControls.tsx
+++ b/src/hooks/usePlotControls.tsx
@@ -57,7 +57,7 @@ type ActionType<DataShape> =
   // add reset all
   | { type: 'onResetAll' }
   // add valueSpec for XYPlotControls
-  | { type: 'scatterplot/onValueSpecChange'; payload: string };
+  | { type: 'XYPlot/onValueSpecChange'; payload: string };
 
 /** Reducer that is used inside the hook. */
 function reducer<DataShape extends UnionOfPlotDataTypes>(
@@ -195,11 +195,11 @@ function reducer<DataShape extends UnionOfPlotDataTypes>(
     case 'onResetAll':
       return { ...state };
     // add valueSpec for XYPlotControls
-    case 'scatterplot/onValueSpecChange':
+    case 'XYPlot/onValueSpecChange':
       return {
         ...state,
-        scatterplot: {
-          ...state.scatterplot,
+        XYPlot: {
+          ...state.XYPlot,
           valueSpec: action.payload,
         },
       };
@@ -277,10 +277,10 @@ type PlotSharedState<DataShape extends UnionOfPlotDataTypes> = {
     onIndependentAxisRangeReset?: () => void;
   };
   // valueSpecChange for XYPlotControls
-  scatterplot?: {
-    /** Scatterplot: valueSpec */
+  XYPlot?: {
+    /** XYPlot: valueSpec */
     valueSpec?: string;
-    /** Scatterplot: valueSpec */
+    /** XYPlot: valueSpec */
     onValueSpecChange?: () => void;
   };
 };
@@ -313,7 +313,7 @@ export type usePlotControlsParams<DataShape extends UnionOfPlotDataTypes> = {
     independentAxisRange?: NumberOrDateRange;
   };
   // valueSpec for XYPlotControls
-  scatterplot?: {
+  XYPlot?: {
     valueSpec?: string;
   };
 };
@@ -348,7 +348,7 @@ export default function usePlotControls<DataShape extends UnionOfPlotDataTypes>(
       dependentAxisLogScale: false,
       dependentAxisMode: 'absolute',
     },
-    scatterplot: {
+    XYPlot: {
       valueSpec: 'Raw',
     },
   };
@@ -601,7 +601,7 @@ export default function usePlotControls<DataShape extends UnionOfPlotDataTypes>(
 
   // onValueSpecChange for XYPlotControls
   const onValueSpecChange = (value: string) =>
-    dispatch({ type: 'scatterplot/onValueSpecChange', payload: value });
+    dispatch({ type: 'XYPlot/onValueSpecChange', payload: value });
 
   /**
    * Separate errors attribute from the rest of the reducer state.
@@ -646,9 +646,9 @@ export default function usePlotControls<DataShape extends UnionOfPlotDataTypes>(
     // add reset all
     onResetAll,
     // onValueSpecChange for XYPlotControls
-    scatterplot: {
+    XYPlot: {
       // need to add reducerState here for XYPlotControls
-      ...reducerState.scatterplot,
+      ...reducerState.XYPlot,
       onValueSpecChange,
     },
   };

--- a/src/plots/Barplot.tsx
+++ b/src/plots/Barplot.tsx
@@ -9,7 +9,7 @@ import PlotlyPlot, { PlotProps } from './PlotlyPlot';
 import { Layout } from 'plotly.js';
 
 // in this example, the main variable is 'country'
-export interface BarplotProps extends PlotProps {
+export interface BarplotProps extends Omit<PlotProps, 'width' | 'height'> {
   /** the data series - e.g. one per overlay variable value (sex: 'male', 'female') */
   data: {
     series: {
@@ -21,6 +21,10 @@ export interface BarplotProps extends PlotProps {
       label: string[]; // e.g. India, Pakistan, Mali
     }[];
   };
+  /** The width of the plot in pixels (if number), or CSS length. */
+  width?: number | string;
+  /** The height of the plot in pixels (if number), or CSS length. */
+  height?: number | string;
   /** The orientation of the plot. Defaults to `vertical`  (--> general PlotProp?) */
   orientation: 'vertical' | 'horizontal';
   /** How bars are displayed when there are multiple series. */
@@ -161,12 +165,13 @@ export default function Barplot({
     <PlotlyPlot
       data={plotlyFriendlyData}
       revision={revision}
+      style={{ width: width, height: height }}
       layout={{
         ...layout,
         ...{
           autosize: true,
-          width: width,
-          height: height,
+          // width: width,
+          // height: height,
           margin: props.margin ? props.margin : undefined,
           showlegend: displayLegend,
           selectdirection: orientation === 'vertical' ? 'h' : 'v',

--- a/src/plots/Barplot.tsx
+++ b/src/plots/Barplot.tsx
@@ -60,7 +60,7 @@ export default function Barplot({
   height,
   orientation = 'vertical',
   title,
-  //DKDK do not set default values for axisLabels
+  // do not set default values for axisLabels
   independentAxisLabel,
   dependentAxisLabel,
   showBarValues = false,
@@ -81,16 +81,16 @@ export default function Barplot({
       data.series.map((el: any) => {
         let calculatedOpacity = 1;
 
-        //DKDK set opacity less than unity for overlay & multiple data
+        // set opacity less than unity for overlay & multiple data
         if (barLayout === 'overlay' && data.series.length > 1)
           calculatedOpacity = opacity * 0.75;
 
-        //DKDK check data exist
+        // check data exist
         if (el.label && el.value) {
           return {
             x: orientation === 'vertical' ? el.label : el.value,
             y: orientation === 'vertical' ? el.value : el.label,
-            name: el.name, //DKDK legend name
+            name: el.name, // legend name
             orientation: orientation === 'vertical' ? 'v' : 'h',
             opacity: calculatedOpacity,
             type: 'bar',

--- a/src/stories/plotControls/XYPlotControls.stories.tsx
+++ b/src/stories/plotControls/XYPlotControls.stories.tsx
@@ -26,7 +26,7 @@ export const Basic: Story<usePlotControlsParams<any>> = (args) => {
       labelPlacement={'end'}
       minWidth={235}
       buttonColor={'primary'}
-      setMargin={['5em', '0', '0', '5em']}
+      margins={['5em', '0', '0', '5em']}
     />
   );
 };

--- a/src/stories/plotControls/XYPlotControls.stories.tsx
+++ b/src/stories/plotControls/XYPlotControls.stories.tsx
@@ -6,28 +6,34 @@ import usePlotControls, {
 } from '../../hooks/usePlotControls';
 
 export default {
-  title: 'Plot Controls/Scatterplot',
+  title: 'Plot Controls/XYPlot',
   component: XYPlotControls,
 } as Meta;
 
-export const BasicControls: Story<usePlotControlsParams<any>> = (args) => {
+export const Basic: Story<usePlotControlsParams<any>> = (args) => {
   const controls = usePlotControls<any>({
     data: args.data,
-    scatterplot: args.scatterplot,
+    XYPlot: args.XYPlot,
   });
 
   return (
     <XYPlotControls
-      // label="Scatter Plot Control Panel"
+      // label="XYPlot Control Panel"
       {...controls}
-      {...controls.scatterplot}
+      {...controls.XYPlot}
+      // assign new props' values for tests
+      orientation={'horizontal'}
+      labelPlacement={'end'}
+      minWidth={235}
+      buttonColor={'primary'}
+      setMargin={['5em', '0', '0', '5em']}
     />
   );
 };
 
-BasicControls.args = {
+Basic.args = {
   data: { series: [{ name: 'dummy data', bins: [] }] },
-  scatterplot: {
+  XYPlot: {
     valueSpec: 'Raw',
   },
 };

--- a/src/stories/plots/Barplot.stories.tsx
+++ b/src/stories/plots/Barplot.stories.tsx
@@ -1,9 +1,5 @@
 import { Story, Meta } from '@storybook/react/types-6-0';
-
 import Barplot from '../../plots/Barplot';
-// import usePlotControls from '../../hooks/usePlotControls';
-// import HistogramControls from '../../components/plotControls/HistogramControls';
-// import { HistogramData } from '../../types/plots';
 
 export default {
   title: 'Plots/Barplot',
@@ -25,7 +21,7 @@ const dataSet = {
   ],
 };
 
-//DKDK set initial props
+// set initial props
 const plotWidth = 1000;
 const plotHeight = 600;
 // let plotWidth = 350;
@@ -42,7 +38,7 @@ export const Basic = () => {
       height={plotHeight}
       // title={plotTitle}
       orientation={orientation}
-      //DKDK check this option later
+      // check this option later
       barLayout={barLayout}
       independentAxisLabel={'Independent axis name'}
       dependentAxisLabel={'Dependent axis name'}
@@ -65,7 +61,7 @@ export const EmptyData = () => {
       height={plotHeight}
       // title={plotTitle}
       orientation={orientation}
-      //DKDK check this option later
+      // check this option later
       barLayout={barLayout}
       independentAxisLabel={'Independent axis name'}
       dependentAxisLabel={'Dependent axis name'}
@@ -77,11 +73,11 @@ export const EmptyData = () => {
   );
 };
 
-//DKDK adding storybook control
+// adding storybook control
 const Template = (args: any) => <Barplot {...args} />;
 export const WithStorybookControl: Story<any> = Template.bind({});
 
-//DKDK set default values for args that use default storybook control
+// set default values for args that use default storybook control
 WithStorybookControl.args = {
   data: dataSet,
   width: plotWidth,

--- a/src/stories/widgets/RadioButtonGroup.stories.tsx
+++ b/src/stories/widgets/RadioButtonGroup.stories.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import { Story, Meta } from '@storybook/react/types-6-0';
+
+import RadioButtonGroup, {
+  RadioButtonGroupProps,
+} from '../../components/widgets/RadioButtonGroup';
+
+export default {
+  title: 'Widgets/RadioButtonGroup',
+  component: RadioButtonGroup,
+} as Meta;
+
+const Template: Story<RadioButtonGroupProps> = (args) => {
+  const [selectedOption, setSelectedOption] = useState('Horizontal');
+
+  return (
+    <RadioButtonGroup
+      {...args}
+      onOptionSelected={setSelectedOption}
+      selectedOption={selectedOption}
+      containerStyles={{ ...args.containerStyles, margin: 25 }}
+    />
+  );
+};
+
+export const Basic = Template.bind({});
+Basic.args = {
+  options: ['Horizontal', 'Vertical'],
+  label: 'Custom label',
+  orientation: 'horizontal',
+  labelPlacement: 'end',
+  minWidth: 150,
+  buttonColor: 'primary',
+  margins: ['10em', '0', '0', '10em'],
+};


### PR DESCRIPTION
This is required for the change from box button to radio button for scatterplot viz. This PR includes several works:

- created radio button group widget with various props and made its story
- changed XYPlotControls with the new widget and its story
- changed useControls with the name of XYPlot
- clean-up barplot and its story

A screenshot is attached:

![radiowidget1](https://user-images.githubusercontent.com/12802305/120894444-630edb00-c5e6-11eb-8535-88051898c3c4.png)
