### PR TITLE
add a default prop, fixedrange, at PlotlyPlot

### DIFF
--- a/src/plots/Histogram.tsx
+++ b/src/plots/Histogram.tsx
@@ -350,7 +350,6 @@ export default function Histogram({
     },
     color: textColor,
     range: [minBinStart, maxBinEnd],
-    fixedrange: true,
     tickfont: data.series.length ? {} : { color: 'transparent' },
   };
   const dependentAxisLayout: Layout['yaxis'] | Layout['xaxis'] = {
@@ -371,7 +370,6 @@ export default function Histogram({
           dependentAxisLogScale && val != undefined ? Math.log10(val || 1) : val
         )
       : [0, 10],
-    fixedrange: true,
     dtick: dependentAxisLogScale ? 1 : undefined,
     tickfont: data.series.length ? {} : { color: 'transparent' },
     showline: true,

--- a/src/plots/PlotlyPlot.tsx
+++ b/src/plots/PlotlyPlot.tsx
@@ -50,10 +50,25 @@ export default function PlotlyPlot(props: PlotParams) {
   const finalConfig = useMemo(() => ({ ...config, ...props.config }), [
     props.config,
   ]);
+  // change layout: add axis fixedrange
+  const finalLayout = useMemo(
+    () => ({
+      ...props.layout,
+      xaxis: { ...props.layout.xaxis, fixedrange: true },
+      yaxis: { ...props.layout.yaxis, fixedrange: true },
+    }),
+    [props.layout]
+  );
 
   return (
     <Suspense fallback="Loading...">
-      <Plot {...props} style={finalStyle} config={finalConfig} />
+      {/* set layout props */}
+      <Plot
+        {...props}
+        layout={finalLayout}
+        style={finalStyle}
+        config={finalConfig}
+      />
     </Suspense>
   );
 }


### PR DESCRIPTION
this will address the issue at web-eda, [All visualization plots need static axes (undraggable/unscrollable)](https://github.com/VEuPathDB/web-eda/issues/143)

