### PR TITLE
remove SmoothedMean option in XYPlotControls

### DIFF
--- a/src/components/plotControls/XYPlotControls.tsx
+++ b/src/components/plotControls/XYPlotControls.tsx
@@ -102,7 +102,6 @@ export default function XYPlotControls({
             label="Plot options"
             options={[
               'Raw',
-              'Smoothed mean',
               'Smoothed mean with raw',
               'Best fit line with raw',
             ]}


### PR DESCRIPTION
One of the XYPlotControls option, `SmoothedMean`, is now removed from backend, thus it is also removed at the plot control

Here is a screenshot. Although all options are equally spaced per request by Danica etc., I feel that the space between the `Raw` and `Smoothed Mean With Raw` may be better to be narrowed (or wider), especially without the SmoothedMean option. This may be alleviated with the props, `minWidth`, though

![scatter-control1](https://user-images.githubusercontent.com/12802305/121231314-454bab00-c85e-11eb-885e-fcdecd090a1d.png)
