### PR TITLE
adding radio button item's margin-right prop

### DIFF
--- a/src/components/plotControls/XYPlotControls.tsx
+++ b/src/components/plotControls/XYPlotControls.tsx
@@ -39,6 +39,8 @@ export type XYPlotControlsProps = {
   buttonColor?: 'primary' | 'secondary';
   /** margin of radio button group: string array for top, left, bottom, and left, e.g., ['10em', '0', '0', '10em'] */
   margins?: string[];
+  /** marginRight of radio button item: default 16px from MUI */
+  itemMarginRight?: number | string;
 };
 
 /**
@@ -61,6 +63,7 @@ export default function XYPlotControls({
   minWidth,
   buttonColor,
   margins,
+  itemMarginRight,
 }: XYPlotControlsProps) {
   const { ref, width } = useDimensions<HTMLDivElement>();
 
@@ -110,9 +113,10 @@ export default function XYPlotControls({
             onOptionSelected={onValueSpecChange}
             orientation={orientation}
             labelPlacement={labelPlacement}
-            minWidth={minWidth}
+            // minWidth={minWidth}
             buttonColor={buttonColor}
             margins={margins}
+            itemMarginRight={itemMarginRight}
           />
         )}
       </div>

--- a/src/components/widgets/RadioButtonGroup.tsx
+++ b/src/components/widgets/RadioButtonGroup.tsx
@@ -28,6 +28,8 @@ export type RadioButtonGroupProps = {
   buttonColor?: 'primary' | 'secondary';
   /** margin of radio button group: string array for top, left, bottom, and left, e.g., ['10em', '0', '0', '10em'] */
   margins?: string[];
+  /** marginRight of radio button item: default 16px from MUI */
+  itemMarginRight?: number | string;
 };
 
 /**
@@ -45,6 +47,7 @@ export default function RadioButtonGroup({
   minWidth,
   buttonColor,
   margins,
+  itemMarginRight,
 }: RadioButtonGroupProps) {
   // perhaps not using focused?
   // const [focused, setFocused] = useState(false);
@@ -94,6 +97,7 @@ export default function RadioButtonGroup({
                 // padding: 5,
                 // paddingLeft: 7.5,
                 // paddingRight: 7.5,
+                marginRight: itemMarginRight,
                 fontSize: '0.75em',
                 fontWeight: 400,
                 textTransform: 'capitalize',

--- a/src/stories/plotControls/XYPlotControls.stories.tsx
+++ b/src/stories/plotControls/XYPlotControls.stories.tsx
@@ -24,9 +24,10 @@ export const Basic: Story<usePlotControlsParams<any>> = (args) => {
       // assign new props' values for tests
       orientation={'horizontal'}
       labelPlacement={'end'}
-      minWidth={235}
+      // minWidth={235}
       buttonColor={'primary'}
       margins={['5em', '0', '0', '5em']}
+      itemMarginRight={50}
     />
   );
 };

--- a/src/stories/widgets/RadioButtonGroup.stories.tsx
+++ b/src/stories/widgets/RadioButtonGroup.stories.tsx
@@ -32,4 +32,5 @@ Basic.args = {
   minWidth: 150,
   buttonColor: 'primary',
   margins: ['10em', '0', '0', '10em'],
+  itemMarginRight: 50,
 };


### PR DESCRIPTION
added a new prop to control radio button item's margin-right prop for possibly better alignment of items. A screenshot is attached where itemMarginRight was set to 50

![radiowidget2](https://user-images.githubusercontent.com/12802305/121359870-eb9cbc80-c901-11eb-8c3c-b7170d1df247.png)
