### PR TITLE
legend title example at XYPlot component

### DIFF
--- a/src/plots/XYPlot.tsx
+++ b/src/plots/XYPlot.tsx
@@ -7,7 +7,7 @@ import PlotlyPlot, { PlotProps } from './PlotlyPlot';
 import { Layout } from 'plotly.js';
 import Spinner from '../components/Spinner';
 // import extended legend prop
-import { layoutLegend } from '../types/general';
+import { LayoutLegendTitle } from '../types/plotly-omissions';
 
 export interface ScatterplotProps extends PlotProps {
   /** Data for the scatter plot */
@@ -76,7 +76,7 @@ export default function XYPlot(props: ScatterplotProps) {
     legendTitle,
   } = props;
 
-  const layout: Partial<Layout> & layoutLegend = {
+  const layout: Partial<Layout> & LayoutLegendTitle = {
     xaxis: {
       title: independentAxisLabel ? independentAxisLabel : '',
       range: independentAxisRange, // set this for better display: esp. for CI plot

--- a/src/plots/XYPlot.tsx
+++ b/src/plots/XYPlot.tsx
@@ -6,6 +6,8 @@ import PlotlyPlot, { PlotProps } from './PlotlyPlot';
 // import Layout for typing layout, especially with sliders
 import { Layout } from 'plotly.js';
 import Spinner from '../components/Spinner';
+// import extended legend prop
+import { layoutLegend } from '../types/general';
 
 export interface ScatterplotProps extends PlotProps {
   /** Data for the scatter plot */
@@ -59,6 +61,8 @@ export interface ScatterplotProps extends PlotProps {
   displayLegend?: boolean;
   /** show plotly's built-in controls */
   displayLibraryControls?: boolean;
+  /** legend title */
+  legendTitle?: string;
 }
 
 export default function XYPlot(props: ScatterplotProps) {
@@ -69,9 +73,10 @@ export default function XYPlot(props: ScatterplotProps) {
     independentAxisRange,
     dependentAxisRange,
     data,
+    legendTitle,
   } = props;
 
-  const layout: Partial<Layout> = {
+  const layout: Partial<Layout> & layoutLegend = {
     xaxis: {
       title: independentAxisLabel ? independentAxisLabel : '',
       range: independentAxisRange, // set this for better display: esp. for CI plot
@@ -93,6 +98,16 @@ export default function XYPlot(props: ScatterplotProps) {
     // plot title
     title: {
       text: title ? title : undefined,
+    },
+    // define legend.title
+    legend: {
+      title: {
+        text: legendTitle,
+        font: {
+          size: 14,
+          color: 'black',
+        },
+      },
     },
   };
 

--- a/src/stories/plots/XYPlot.stories.tsx
+++ b/src/stories/plots/XYPlot.stories.tsx
@@ -995,6 +995,8 @@ export const RealDataDate = () => {
       displayLegend={true}
       displayLibraryControls={true}
       // margin={{l: 50, r: 10, b: 20, t: 10}}
+      // add legend title
+      legendTitle={'legend title example'}
     />
   );
 };

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -3,6 +3,9 @@
  * Or, at least, haven't found a more specific home yet.
  */
 
+// import Legend to extend
+import { Legend } from 'plotly.js';
+
 export type NumberOrDate = number | string;
 
 export type ErrorManagement = {
@@ -40,3 +43,19 @@ export type TimeDelta = { value: number; unit: string };
 export type NumberOrTimeDelta = number | TimeDelta;
 export type NumberOrDateRange = NumberRange | DateRange;
 export type NumberOrTimeDeltaRange = NumberRange | TimeDeltaRange;
+
+// extend legend type: somehow plotly.js did not define legend.title type
+// see https://plotly.com/javascript/reference/layout/#layout-legend-title
+export interface layoutLegend extends Partial<Legend> {
+  legend?: {
+    title?: {
+      text?: string;
+      font?: {
+        family?: string;
+        size?: number;
+        color?: string;
+      };
+      side?: 'top' | 'left' | 'top left';
+    };
+  };
+}

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -3,9 +3,6 @@
  * Or, at least, haven't found a more specific home yet.
  */
 
-// import Legend to extend
-import { Legend } from 'plotly.js';
-
 export type NumberOrDate = number | string;
 
 export type ErrorManagement = {
@@ -43,19 +40,3 @@ export type TimeDelta = { value: number; unit: string };
 export type NumberOrTimeDelta = number | TimeDelta;
 export type NumberOrDateRange = NumberRange | DateRange;
 export type NumberOrTimeDeltaRange = NumberRange | TimeDeltaRange;
-
-// extend legend type: somehow plotly.js did not define legend.title type
-// see https://plotly.com/javascript/reference/layout/#layout-legend-title
-export interface layoutLegend extends Partial<Legend> {
-  legend?: {
-    title?: {
-      text?: string;
-      font?: {
-        family?: string;
-        size?: number;
-        color?: string;
-      };
-      side?: 'top' | 'left' | 'top left';
-    };
-  };
-}

--- a/src/types/plotly-omissions.ts
+++ b/src/types/plotly-omissions.ts
@@ -1,0 +1,21 @@
+/**
+ * General type definitions that don't fit into a more specialized category.
+ * Or, at least, haven't found a more specific home yet.
+ */
+
+// extend legend type: somehow plotly.js did not define legend.title type
+// see https://plotly.com/javascript/reference/layout/#layout-legend-title
+// export interface layoutLegend extends Partial<Legend> {
+export interface LayoutLegendTitle {
+  legend?: {
+    title?: {
+      text?: string;
+      font?: {
+        family?: string;
+        size?: number;
+        color?: string;
+      };
+      side?: 'top' | 'left' | 'top left';
+    };
+  };
+}


### PR DESCRIPTION
examined and tested to add legend title using XYPlot component. If acceptable, then I will add this approach to other plot components. A screenshot with an exemplary title of `legend title example` is attached:

![legend-title-example](https://user-images.githubusercontent.com/12802305/121989081-8154a380-cd69-11eb-9a0b-0804e27c6dbc.png)
