### PR TITLE
Add independentAxisRange prop to Histogram and custom validators to number/date inputs

### DIFF
--- a/src/components/plotControls/AxisRangeControl.tsx
+++ b/src/components/plotControls/AxisRangeControl.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { NumberOrDateRange, NumberRange, DateRange } from '../../types/general';
 import {
   ValueTypeAddon,
@@ -26,6 +27,26 @@ export default function AxisRangeControl({
   onRangeChange,
   containerStyles,
 }: AxisRangeControlProps) {
+  const validator = useCallback((range?: NumberOrDateRange): {
+    validity: boolean;
+    message: string;
+  } => {
+    if (range) {
+      if (range.min === range.max) {
+        return {
+          validity: false,
+          message: 'Start and end of range cannot be the same',
+        };
+      } else if (range.min > range.max) {
+        return {
+          validity: false,
+          message: 'End cannot be before start of range',
+        };
+      }
+    }
+    return { validity: true, message: '' };
+  }, []);
+
   return onRangeChange ? (
     valueType != null && valueType === 'date' ? (
       <DateRangeInput
@@ -34,6 +55,7 @@ export default function AxisRangeControl({
         onRangeChange={onRangeChange}
         allowPartialRange={false}
         containerStyles={containerStyles}
+        validator={validator}
       />
     ) : (
       <NumberRangeInput
@@ -42,6 +64,7 @@ export default function AxisRangeControl({
         onRangeChange={onRangeChange}
         allowPartialRange={false}
         containerStyles={containerStyles}
+        validator={validator}
       />
     )
   ) : null;

--- a/src/components/widgets/Notification.tsx
+++ b/src/components/widgets/Notification.tsx
@@ -11,7 +11,9 @@ export type NotificationProps = {
   text: string;
   /** Function to invoke when notification is acknowledged. */
   onAcknowledgement: () => void;
-  /** Number of times this notification has been received. */
+  /** Number of times this notification has been received.
+   * If not provided, no occurrence count is shown.
+   * */
   occurences?: number;
   /** Background color for notification. Any acceptable CSS color definition.
    * Defaults to LIGHT_GREEN. */
@@ -26,7 +28,7 @@ export default function Notification({
   title,
   text,
   onAcknowledgement,
-  occurences = 1,
+  occurences,
   color = LIGHT_GREEN,
   containerStyles = {},
 }: NotificationProps) {
@@ -50,27 +52,29 @@ export default function Notification({
         <Typography variant="button" style={{ color: 'white' }}>
           {title}
         </Typography>
-        <div
-          style={{
-            backgroundColor: 'white',
-            borderRadius: 5,
-            height: 20,
-            width: 20,
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-          }}
-        >
-          <span
+        {occurences != null ? (
+          <div
             style={{
-              color: color,
-              fontFamily: 'Roboto, Helvetica, Arial, sans-serif',
-              fontSize: 11,
+              backgroundColor: 'white',
+              borderRadius: 5,
+              height: 20,
+              width: 20,
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center',
             }}
           >
-            {occurences}
-          </span>
-        </div>
+            <span
+              style={{
+                color: color,
+                fontFamily: 'Roboto, Helvetica, Arial, sans-serif',
+                fontSize: 11,
+              }}
+            >
+              {occurences}
+            </span>
+          </div>
+        ) : null}
       </div>
       <div style={{ display: 'flex', flexDirection: 'row' }}>
         <span

--- a/src/components/widgets/NumberAndDateRangeInputs.tsx
+++ b/src/components/widgets/NumberAndDateRangeInputs.tsx
@@ -105,7 +105,6 @@ function BaseInput({
     if (!isReceiving) {
       if (
         localRange &&
-        (localRange.min !== range?.min || localRange.max !== range?.max) &&
         (allowPartialRange ||
           (localRange.min != null && localRange.max != null))
       ) {
@@ -113,7 +112,10 @@ function BaseInput({
           ? validator(localRange)
           : { validity: true, message: '' };
         if (validity) {
-          onRangeChange(localRange);
+          // communicate the change if there is a change
+          if (localRange.min !== range?.min || localRange.max !== range?.max) {
+            onRangeChange(localRange);
+          }
           setValidationWarning('');
         } else {
           setValidationWarning(message);

--- a/src/plots/Histogram.tsx
+++ b/src/plots/Histogram.tsx
@@ -239,7 +239,7 @@ export default function Histogram({
         }
       }
     },
-    [data.valueType, orientation, binSummaries, setSelectingRange]
+    [orientation, binSummaries]
   );
 
   // handle finshed/completed (graphical) range selection
@@ -257,6 +257,11 @@ export default function Histogram({
   const selectedRangeHighlighting: Partial<Shape>[] = useMemo(() => {
     const range = selectingRange ?? selectedRange;
     if (data.series.length && range) {
+      // for dates, draw the blue area to the end of the day
+      const rightCoordinate =
+        data.valueType === 'number'
+          ? range.max
+          : DateMath.endOf(new Date(range.max), 'day').toISOString();
       return [
         {
           type: 'rect',
@@ -265,7 +270,7 @@ export default function Histogram({
                 xref: 'x',
                 yref: 'paper',
                 x0: range.min,
-                x1: range.max,
+                x1: rightCoordinate,
                 y0: 0,
                 y1: 1,
               }
@@ -275,7 +280,7 @@ export default function Histogram({
                 x0: 0,
                 x1: 1,
                 y0: range.min,
-                y1: range.max,
+                y1: rightCoordinate,
               }),
           line: {
             color: 'blue',

--- a/src/plots/Histogram.tsx
+++ b/src/plots/Histogram.tsx
@@ -198,7 +198,7 @@ export default function Histogram({
               new Date(bin.binStart as string),
               DateMath.diff(
                 new Date(bin.binStart as string),
-                new Date(bin.binEnd as string),
+                DateMath.endOf(new Date(bin.binEnd as string), 'day'),
                 'seconds',
                 false
               ) * 500,
@@ -218,8 +218,14 @@ export default function Histogram({
           orientation === 'vertical' ? object.range.x : object.range.y;
         const [min, max] = val1 > val2 ? [val2, val1] : [val1, val2];
         // TO DO: think about time zones?
-        const rawRange: NumberOrDateRange = { min, max };
-
+        // ISO-ify time part of plotly's response
+        //// console.log(`${min} to ${max} raw`);
+        const rawRange: NumberOrDateRange = {
+          min: min.replace(/ /, 'T').replace(/\.\d+$/, ''),
+          max: max.replace(/ /, 'T').replace(/\.\d+$/, ''),
+        };
+        //// console.log(`${rawRange.min} to ${rawRange.max} selected`);
+        //// console.log(binSummaries.slice().reverse());
         // now snap to bin boundaries using same logic that Plotly uses
         // (dragging range past middle of bin selects it)
         const leftBin = binSummaries.find(

--- a/src/plots/Histogram.tsx
+++ b/src/plots/Histogram.tsx
@@ -295,6 +295,20 @@ export default function Histogram({
     }
   }, [selectingRange, selectedRange, orientation, data.series]);
 
+  const plotlyIndependentAxisRange = useMemo(() => {
+    const range = independentAxisRange
+      ? [independentAxisRange.min, independentAxisRange.max]
+      : [minBinStart, maxBinEnd];
+    if (data?.valueType === 'date') {
+      return [
+        range[0],
+        DateMath.endOf(new Date(range[1]), 'day').toISOString(),
+      ];
+    } else {
+      return range;
+    }
+  }, [data?.valueType, independentAxisRange, minBinStart, maxBinEnd]);
+
   const independentAxisLayout: Layout['xaxis'] | Layout['yaxis'] = {
     type: data?.valueType === 'date' ? 'date' : 'linear',
     automargin: true,
@@ -304,14 +318,7 @@ export default function Histogram({
     title: {
       text: independentAxisLabel,
     },
-    range: [
-      independentAxisRange && independentAxisRange.min < minBinStart
-        ? independentAxisRange.min
-        : minBinStart,
-      independentAxisRange && independentAxisRange?.max > maxBinEnd
-        ? independentAxisRange.max
-        : maxBinEnd,
-    ],
+    range: plotlyIndependentAxisRange,
     tickfont: data.series.length ? {} : { color: 'transparent' },
   };
   const dependentAxisLayout: Layout['yaxis'] | Layout['xaxis'] = {

--- a/src/plots/Histogram.tsx
+++ b/src/plots/Histogram.tsx
@@ -123,7 +123,7 @@ export default function Histogram({
             return (
               DateMath.diff(
                 new Date(bin.binStart as string),
-                new Date(bin.binEnd as string),
+                DateMath.endOf(new Date(bin.binEnd as string), 'day'),
                 'seconds',
                 false
               ) * 1000

--- a/src/plots/Histogram.tsx
+++ b/src/plots/Histogram.tsx
@@ -55,6 +55,8 @@ export interface HistogramProps
   selectedRangeBounds?: NumberOrDateRange; // TO DO: handle DateRange too
   /** Relevant to range selection - flag to indicate if the data is zoomed in. Default false. */
   isZoomed?: boolean;
+  /** independent axis range min and max (this will be widened to include data if needed) */
+  independentAxisRange?: NumberOrDateRange;
 }
 
 /** A Plot.ly based histogram component. */
@@ -72,6 +74,7 @@ export default function Histogram({
   onSelectedRangeChange = () => {},
   selectedRangeBounds,
   isZoomed = false,
+  independentAxisRange,
   ...restProps
 }: HistogramProps) {
   /**
@@ -296,7 +299,14 @@ export default function Histogram({
     title: {
       text: independentAxisLabel,
     },
-    range: [minBinStart, maxBinEnd],
+    range: [
+      independentAxisRange && independentAxisRange.min < minBinStart
+        ? independentAxisRange.min
+        : minBinStart,
+      independentAxisRange && independentAxisRange?.max > maxBinEnd
+        ? independentAxisRange.max
+        : maxBinEnd,
+    ],
     tickfont: data.series.length ? {} : { color: 'transparent' },
   };
   const dependentAxisLayout: Layout['yaxis'] | Layout['xaxis'] = {

--- a/src/plots/Histogram.tsx
+++ b/src/plots/Histogram.tsx
@@ -217,7 +217,7 @@ export default function Histogram({
         const [val1, val2] =
           orientation === 'vertical' ? object.range.x : object.range.y;
         const [min, max] = val1 > val2 ? [val2, val1] : [val1, val2];
-        // TO DO: think about time zones?
+        // TO DO: carefully test/debug time zones and different browsers
         // ISO-ify time part of plotly's response
         const rawRange: NumberOrDateRange = {
           min: min.replace(/ /, 'T').replace(/\.\d+$/, ''),

--- a/src/stories/plots/Histogram.stories.tsx
+++ b/src/stories/plots/Histogram.stories.tsx
@@ -8,6 +8,7 @@ import {
 
 import Histogram, { HistogramProps } from '../../plots/Histogram';
 import HistogramControls from '../../components/plotControls/HistogramControls';
+import AxisRangeControl from '../../components/plotControls/AxisRangeControl';
 import { binDailyCovidStats } from '../api/covidData';
 import { binGithubEventDates } from '../api/githubDates';
 import { HistogramData } from '../../types/plots';
@@ -81,6 +82,9 @@ const TemplateWithSelectedRangeControls: Story<Omit<HistogramProps, 'data'>> = (
   const [binWidth, setBinWidth] = useState<number>(500);
   const [selectedRange, setSelectedRange] = useState<NumberOrDateRange>();
   const [loading, setLoading] = useState<boolean>(true);
+  const [independentAxisRange, setIndependentAxisRange] = useState<
+    NumberOrDateRange
+  >();
 
   const handleBinWidthChange = async (newBinWidth: NumberOrTimeDelta) => {
     if (newBinWidth > 0) {
@@ -90,6 +94,12 @@ const TemplateWithSelectedRangeControls: Story<Omit<HistogramProps, 'data'>> = (
 
   const handleSelectedRangeChange = async (newRange?: NumberOrDateRange) => {
     setSelectedRange(newRange);
+  };
+
+  const handleIndependentAxisRangeChange = async (
+    newRange?: NumberOrDateRange
+  ) => {
+    setIndependentAxisRange(newRange);
   };
 
   // keep `data` up to date
@@ -120,6 +130,7 @@ const TemplateWithSelectedRangeControls: Story<Omit<HistogramProps, 'data'>> = (
         interactive={true}
         selectedRange={selectedRange}
         onSelectedRangeChange={handleSelectedRangeChange}
+        independentAxisRange={independentAxisRange}
       />
       <div style={{ height: 25 }} />
       <HistogramControls
@@ -131,6 +142,11 @@ const TemplateWithSelectedRangeControls: Story<Omit<HistogramProps, 'data'>> = (
         onBinWidthChange={handleBinWidthChange}
         selectedRange={selectedRange}
         onSelectedRangeChange={handleSelectedRangeChange}
+      />
+      <AxisRangeControl
+        label="Manual x-range control (you can only set it wider than data range)"
+        range={independentAxisRange}
+        onRangeChange={handleIndependentAxisRangeChange}
       />
     </div>
   );
@@ -200,6 +216,9 @@ const TemplateWithSelectedDateRangeControls: Story<Omit<
   const [data, setData] = useState<HistogramData>();
   const [selectedRange, setSelectedRange] = useState<NumberOrDateRange>();
   const [loading, setLoading] = useState<boolean>(true);
+  const [independentAxisRange, setIndependentAxisRange] = useState<
+    NumberOrDateRange
+  >();
   const [binWidth, setBinWidth] = useState<NumberOrTimeDelta>({
     value: 1,
     unit: 'month',
@@ -218,6 +237,12 @@ const TemplateWithSelectedDateRangeControls: Story<Omit<
 
   const handleBinWidthChange = async (newBinWidth: NumberOrTimeDelta) =>
     setBinWidth(newBinWidth);
+
+  const handleIndependentAxisRangeChange = async (
+    newRange?: NumberOrDateRange
+  ) => {
+    setIndependentAxisRange(newRange);
+  };
 
   // keep `data` up to date
   useEffect(() => {
@@ -249,10 +274,10 @@ const TemplateWithSelectedDateRangeControls: Story<Omit<
         showSpinner={loading}
         selectedRange={selectedRange}
         onSelectedRangeChange={handleSelectedRangeChange}
+        independentAxisRange={independentAxisRange}
       />
       <div style={{ height: 25 }} />
       <HistogramControls
-        label="Histogram Controls"
         valueType="date"
         selectedRange={selectedRange}
         onSelectedRangeChange={handleSelectedRangeChange}
@@ -266,6 +291,12 @@ const TemplateWithSelectedDateRangeControls: Story<Omit<
         selectedUnit={unit}
         availableUnits={['week', 'month']}
         onSelectedUnitChange={handleUnitChange}
+      />
+      <AxisRangeControl
+        label="Manual x-range control (you can only set it wider than data range)"
+        range={independentAxisRange}
+        onRangeChange={handleIndependentAxisRangeChange}
+        valueType="date"
       />
     </div>
   );

--- a/src/stories/widgets/DateInput.stories.tsx
+++ b/src/stories/widgets/DateInput.stories.tsx
@@ -116,8 +116,10 @@ export const CustomValidator = ControlledTemplate.bind({});
 CustomValidator.args = {
   label: 'Weekdays only',
   validator: (newValue) => {
-    // allow empty values in this case
+    // allow empty values in this case (emulates `required: false`)
     if (newValue == null) return { validity: true, message: '' };
+    // uncomment to emulate `required: true` functionality
+    // if (newValue == null) return { validity: false, message: 'please pick a day' };
 
     const date = new Date(newValue);
     if (date) {

--- a/src/stories/widgets/DateInput.stories.tsx
+++ b/src/stories/widgets/DateInput.stories.tsx
@@ -12,7 +12,7 @@ export default {
 } as Meta;
 
 const ControlledTemplate: Story<DateInputProps> = (args) => {
-  const [value, setValue] = useState<string>('2005-01-01');
+  const [value, setValue] = useState<string>('2005-01-03');
   const onValueChange = useCallback(
     (newValue) => {
       console.log(`new value = ${newValue}`);
@@ -110,4 +110,24 @@ export const ControlledBounds: Story = () => {
       />
     </>
   );
+};
+
+export const CustomValidator = ControlledTemplate.bind({});
+CustomValidator.args = {
+  label: 'Weekdays only',
+  validator: (newValue) => {
+    // allow empty values in this case
+    if (newValue == null) return { validity: true, message: '' };
+
+    const date = new Date(newValue);
+    if (date) {
+      if (date.getDay() > 0 && date.getDay() < 6) {
+        return { validity: true, message: '' };
+      } else {
+        return { validity: false, message: 'Please pick a weekday' };
+      }
+    } else {
+      return { validity: false, message: 'badly formatted date' };
+    }
+  },
 };

--- a/src/stories/widgets/NumberInput.stories.tsx
+++ b/src/stories/widgets/NumberInput.stories.tsx
@@ -176,3 +176,18 @@ export const ControlledBounds: Story = () => {
     </>
   );
 };
+
+export const CustomValidator = ControlledTemplate.bind({});
+CustomValidator.args = {
+  label: 'Even numbers 0 <= x <= 10',
+  validator: (newValue) => {
+    const validity =
+      newValue != null &&
+      typeof newValue === 'number' &&
+      newValue >= 0 &&
+      newValue <= 10 &&
+      newValue % 2 == 0;
+    return { validity, message: validity ? '' : 'Not an even number 0 to 10' };
+  },
+  containerStyles: { width: '40ch' },
+};

--- a/src/stories/widgets/NumberRangeInput.stories.tsx
+++ b/src/stories/widgets/NumberRangeInput.stories.tsx
@@ -96,3 +96,41 @@ export const ControlledLinked: Story<NumberRangeInputProps> = () => {
     </>
   );
 };
+
+export const CustomValidator: Story<NumberRangeInputProps> = () => {
+  const [range, setRange] = useState<NumberRange | undefined>();
+
+  const handleChange = useCallback(
+    (newRange) => {
+      console.log(`new range = ${newRange?.min} to ${newRange?.max}`);
+      setRange(newRange);
+    },
+    [setRange]
+  );
+  const validate = useCallback(
+    (range) => {
+      console.log(`validating range ${range.min} to ${range.max}`);
+      if (range && range.max != null && range.min != null) {
+        if (range.max - range.min === 5) {
+          return { validity: true, message: '' };
+        } else {
+          return { validity: false, message: 'range is not 5' };
+        }
+      } else {
+        // return { validity: true, message: '' }; // like `required: false` (no warning for empty or partially entered range)
+        return { validity: false, message: 'enter two numbers' }; // like `required: true` (warnings for the above)
+      }
+    },
+    [range]
+  );
+
+  return (
+    <NumberRangeInput
+      label="Range must have width of 5"
+      onRangeChange={handleChange}
+      range={range}
+      validator={validate}
+      containerStyles={{ width: '400px' }}
+    />
+  );
+};


### PR DESCRIPTION
This is needed for https://github.com/VEuPathDB/web-eda/issues/198 because the histogram usually scales its x-axis to the min/max of the data.  Now you can specify a **wider** range with this prop, but not a narrower one.  This means that all data bins are always shown.  (If you need to zoom in, then provide zoomed data.)

An ugly story is added to both of the SelectedRange stories (number and date) to demo the independentAxisRange control.
