### PR TITLE
Log axis for barplot and log tick number formatting

### DIFF
--- a/src/components/widgets/NumberAndDateInputs.tsx
+++ b/src/components/widgets/NumberAndDateInputs.tsx
@@ -122,7 +122,7 @@ function BaseInput({
         } else if (maxValue != null && newValue > maxValue) {
           return {
             validity: false,
-            message: `Sorry, value can't go above ${minValue}!`,
+            message: `Sorry, value can't go above ${maxValue}!`,
           };
         } else {
           return { validity: true, message: '' };

--- a/src/plots/Barplot.tsx
+++ b/src/plots/Barplot.tsx
@@ -7,6 +7,8 @@ import {
   OpacityDefault,
   OrientationAddon,
   OrientationDefault,
+  DependentAxisLogScaleAddon,
+  DependentAxisLogScaleDefault,
 } from '../types/plots';
 import PlotlyPlot, { PlotProps } from './PlotlyPlot';
 import { Layout } from 'plotly.js';
@@ -16,7 +18,8 @@ export interface BarplotProps
   extends PlotProps<BarplotData>,
     BarLayoutAddon<'overlay' | 'stack' | 'group'>,
     OrientationAddon,
-    OpacityAddon {
+    OpacityAddon,
+    DependentAxisLogScaleAddon {
   /** Label for independent axis. e.g. 'Country' */
   independentAxisLabel?: string;
   /** Label for dependent axis. Defaults to 'Count' */
@@ -42,6 +45,7 @@ export default function Barplot({
   barLayout = 'group',
   showIndependentAxisTickLabel = true,
   showDependentAxisTickLabel = true,
+  dependentAxisLogScale = DependentAxisLogScaleDefault,
   ...restProps
 }: BarplotProps) {
   // Transform `data` into a Plot.ly friendly format.
@@ -86,6 +90,8 @@ export default function Barplot({
 
   const dependentAxisLayout: Layout['yaxis'] | Layout['xaxis'] = {
     automargin: true,
+    tickformat: ',.1r', // comma-separated thousands, rounded to 1 significant digit
+    type: dependentAxisLogScale ? 'log' : 'linear',
     title: {
       text: dependentAxisLabel ? dependentAxisLabel : '',
     },

--- a/src/plots/Histogram.tsx
+++ b/src/plots/Histogram.tsx
@@ -10,6 +10,8 @@ import {
   OrientationAddon,
   OrientationDefault,
   BarLayoutAddon,
+  DependentAxisLogScaleAddon,
+  DependentAxisLogScaleDefault,
 } from '../types/plots';
 import { NumberOrDate, NumberOrDateRange, NumberRange } from '../types/general';
 
@@ -34,7 +36,8 @@ export interface HistogramProps
   extends PlotProps<HistogramData>,
     OrientationAddon,
     OpacityAddon,
-    BarLayoutAddon<'overlay' | 'stack'> {
+    BarLayoutAddon<'overlay' | 'stack'>,
+    DependentAxisLogScaleAddon {
   /** Label for independent axis. Defaults to `Bins`. */
   independentAxisLabel?: string;
   /** Label for dependent axis. Defaults to `Count`. */
@@ -42,8 +45,6 @@ export interface HistogramProps
   /** Range for the dependent axis (usually y-axis) */
   // can only be numeric
   dependentAxisRange?: NumberRange;
-  /** Use a log scale for dependent axis. Default is false */
-  dependentAxisLogScale?: boolean;
   /** Show value for each bar */
   showValues?: boolean;
   /** A range to highlight by means of opacity */
@@ -68,7 +69,7 @@ export default function Histogram({
   opacity = OpacityDefault,
   barLayout = 'overlay',
   dependentAxisRange,
-  dependentAxisLogScale = false,
+  dependentAxisLogScale = DependentAxisLogScaleDefault,
   showValues,
   selectedRange,
   onSelectedRangeChange = () => {},
@@ -340,6 +341,7 @@ export default function Histogram({
   };
   const dependentAxisLayout: Layout['yaxis'] | Layout['xaxis'] = {
     type: dependentAxisLogScale ? 'log' : 'linear',
+    tickformat: ',.1r', // comma-separated thousands, rounded to 1 significant digit
     automargin: true,
     title: {
       text: dependentAxisLabel,

--- a/src/types/plots/addOns.ts
+++ b/src/types/plots/addOns.ts
@@ -53,6 +53,12 @@ export type OpacityAddon = {
 };
 export const OpacityDefault: number = 0.5;
 
+export type DependentAxisLogScaleAddon = {
+  /** Use a log scale for dependent axis. Default is false */
+  dependentAxisLogScale?: boolean;
+};
+export const DependentAxisLogScaleDefault: boolean = false;
+
 /** BarLayout - options and default differ depending on usage */
 export type BarLayoutAddon<O extends BarLayoutOptions> = {
   /** How bars are displayed when there are multiple series. */


### PR DESCRIPTION
Generalised `dependentAxisLogRange` into an AddOn that works for histogram and barplot.
