### PR TITLE
CategoricalAxis addOn for axis tick ordering

### DIFF
--- a/src/plots/Barplot.tsx
+++ b/src/plots/Barplot.tsx
@@ -3,6 +3,8 @@ import { PlotParams } from 'react-plotly.js';
 import {
   BarLayoutAddon,
   BarplotData,
+  CategoricalAxisAddon,
+  categoricalAxisPlotlyProps,
   OpacityAddon,
   OpacityDefault,
   OrientationAddon,
@@ -16,7 +18,8 @@ export interface BarplotProps
   extends PlotProps<BarplotData>,
     BarLayoutAddon<'overlay' | 'stack' | 'group'>,
     OrientationAddon,
-    OpacityAddon {
+    OpacityAddon,
+    CategoricalAxisAddon {
   /** Label for independent axis. e.g. 'Country' */
   independentAxisLabel?: string;
   /** Label for dependent axis. Defaults to 'Count' */
@@ -42,6 +45,8 @@ export default function Barplot({
   barLayout = 'group',
   showIndependentAxisTickLabel = true,
   showDependentAxisTickLabel = true,
+  categoricalAxisCategoryOrder,
+  categoricalAxisOrderMethod,
   ...restProps
 }: BarplotProps) {
   // Transform `data` into a Plot.ly friendly format.
@@ -82,6 +87,10 @@ export default function Barplot({
     range: data.series.length ? undefined : [0, 10],
     tickfont: data.series.length ? {} : { color: 'transparent' },
     showticklabels: showIndependentAxisTickLabel,
+    ...categoricalAxisPlotlyProps(
+      categoricalAxisOrderMethod,
+      categoricalAxisCategoryOrder
+    ),
   };
 
   const dependentAxisLayout: Layout['yaxis'] | Layout['xaxis'] = {

--- a/src/plots/Boxplot.tsx
+++ b/src/plots/Boxplot.tsx
@@ -4,6 +4,8 @@ import { PlotParams } from 'react-plotly.js';
 import PlotlyPlot, { PlotProps } from './PlotlyPlot';
 import {
   BoxplotData,
+  CategoricalAxisAddon,
+  categoricalAxisPlotlyProps,
   OpacityAddon,
   OpacityDefault,
   OrientationAddon,
@@ -14,7 +16,8 @@ import { NumberOrDateRange } from '../types/general';
 export interface BoxplotProps
   extends PlotProps<BoxplotData>,
     OrientationAddon,
-    OpacityAddon {
+    OpacityAddon,
+    CategoricalAxisAddon {
   /** label for independent axis */
   independentAxisLabel?: string;
   /** label for the (typically) y-axis, e.g. Wealth */
@@ -47,6 +50,8 @@ export default function Boxplot(props: BoxplotProps) {
     showIndependentAxisTickLabel = true,
     showDependentAxisTickLabel = true,
     dependentValueType = 'number',
+    categoricalAxisOrderMethod,
+    categoricalAxisCategoryOrder,
     ...restProps
   } = props;
 
@@ -104,6 +109,10 @@ export default function Boxplot(props: BoxplotProps) {
       range: data.length ? undefined : [1, 5], // avoids x==0 line
       tickfont: data.length ? {} : { color: 'transparent' },
       showticklabels: showIndependentAxisTickLabel,
+      ...categoricalAxisPlotlyProps(
+        categoricalAxisOrderMethod,
+        categoricalAxisCategoryOrder
+      ),
     },
     [dependentAxis]: {
       automargin: true,

--- a/src/types/plots/addOns.ts
+++ b/src/types/plots/addOns.ts
@@ -84,6 +84,7 @@ export type CategoricalAxisAddon = {
    * default = use categoricalAxisCategoryOrder (or if not provided, use the order already in the data)
    * ascending/descending = alphanumeric sort of category label
    * values ascending/descending = sort by sum of values for each category (e.g. total stacked bar height)
+   * (this doesn't seem to work for boxplots constructed with summary data)
    */
   categoricalAxisOrderMethod?:
     | 'default'
@@ -99,7 +100,7 @@ export type CategoricalAxisAddon = {
 export function categoricalAxisPlotlyProps(
   method?: CategoricalAxisAddon['categoricalAxisOrderMethod'],
   order?: CategoricalAxisAddon['categoricalAxisCategoryOrder']
-): Layout['xaxis'] {
+): Partial<Layout['xaxis']> {
   if (method == null || method === 'default') {
     if (order != null) {
       return {
@@ -116,7 +117,7 @@ export function categoricalAxisPlotlyProps(
       case 'labels descending':
         return { categoryorder: 'category descending' };
       case 'values ascending':
-        return { categoryorder: 'sum ascending' };
+        return { categoryorder: 'sum ascending' }; // even 'mean ascending' doesn't work well for our pre-calculated boxplots
       case 'values descending':
         return { categoryorder: 'sum descending' };
       default:

--- a/src/types/plots/addOns.ts
+++ b/src/types/plots/addOns.ts
@@ -2,6 +2,7 @@
  * Additional reusable modules to extend PlotProps and PlotData props
  */
 
+import { Layout } from 'plotly.js';
 import { CSSProperties } from 'react';
 import { BarLayoutOptions, OrientationOptions } from '.';
 
@@ -76,6 +77,53 @@ export type ContainerStylesAddon = {
   /** Additional styles for component's container. Optional */
   containerStyles?: CSSProperties;
 };
+
+/** categorical axes */
+export type CategoricalAxisAddon = {
+  /** sort method:
+   * default = use categoricalAxisCategoryOrder (or if not provided, use the order already in the data)
+   * ascending/descending = alphanumeric sort of category label
+   * values ascending/descending = sort by sum of values for each category (e.g. total stacked bar height)
+   */
+  categoricalAxisOrderMethod?:
+    | 'default'
+    | 'labels ascending'
+    | 'labels descending'
+    | 'values ascending'
+    | 'values descending';
+  /** desired order of categories */
+  categoricalAxisCategoryOrder?: string[];
+};
+
+/** helper function to process Categorical Axis props into plotly axis props */
+export function categoricalAxisPlotlyProps(
+  method?: CategoricalAxisAddon['categoricalAxisOrderMethod'],
+  order?: CategoricalAxisAddon['categoricalAxisCategoryOrder']
+): Layout['xaxis'] {
+  if (method == null || method === 'default') {
+    if (order != null) {
+      return {
+        categoryorder: 'array',
+        categoryarray: order,
+      };
+    } else {
+      return {};
+    }
+  } else {
+    switch (method) {
+      case 'labels ascending':
+        return { categoryorder: 'category ascending' };
+      case 'labels descending':
+        return { categoryorder: 'category descending' };
+      case 'values ascending':
+        return { categoryorder: 'sum ascending' };
+      case 'values descending':
+        return { categoryorder: 'sum descending' };
+      default:
+        return {};
+    }
+  }
+}
 
 /** PlotData addons */
 export type AvailableUnitsAddon =


### PR DESCRIPTION
This is **almost** what we need for ordering plots with categorical independent axes.

You can play around with the new props in `categoricalAxisOrderMethod` and `categoricalAxisCategoryOrder`
http://localhost:62331/?path=/story/plots-barplot--basic

If you add a category (elephants) without data to the order prop `["cats","elephants","dogs","monkeys"]` then it shows up as you would want on the plot
![image](https://user-images.githubusercontent.com/308639/127032681-248c59c4-093c-4367-b840-5246a52867ef.png)

UNLESS it is the first or last element in the list:
`["elephants","cats","dogs","monkeys"]`
`["cats","dogs","monkeys","elephants"]`

So perhaps this is a plotly bug we can report and fix?