### PR TITLE
Use explicitly installed package import

### DIFF
--- a/src/components/widgets/Button.tsx
+++ b/src/components/widgets/Button.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
 import MaterialButton from '@material-ui/core/Button';
-import { ThemeProvider } from '@material-ui/styles';
 
 import { LIGHT_BLUE } from '../../constants/colors';
 

--- a/src/components/widgets/Switch.tsx
+++ b/src/components/widgets/Switch.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
-import { createMuiTheme } from '@material-ui/core/styles';
-import { ThemeProvider } from '@material-ui/styles';
+import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
 import { Typography } from '@material-ui/core';
 import MaterialSwitch from '@material-ui/core/Switch';
 


### PR DESCRIPTION
The previous import was using an implicitly installed package (`@material-ui/styles`). This causes compile issues when _this package_ is used as a dependency.

Instead, we should use `@material-ui/core/styles`, since it is explicitly included in `package.json`. 