### PR TITLE
Excessive rounding on y-axis tick numbers bugfix

### DIFF
--- a/src/plots/Barplot.tsx
+++ b/src/plots/Barplot.tsx
@@ -90,7 +90,7 @@ export default function Barplot({
 
   const dependentAxisLayout: Layout['yaxis'] | Layout['xaxis'] = {
     automargin: true,
-    tickformat: ',.1r', // comma-separated thousands, rounded to 1 significant digit
+    tickformat: dependentAxisLogScale ? ',.1r' : undefined, // comma-separated thousands, rounded to 1 significant digit
     type: dependentAxisLogScale ? 'log' : 'linear',
     title: {
       text: dependentAxisLabel ? dependentAxisLabel : '',

--- a/src/plots/Barplot.tsx
+++ b/src/plots/Barplot.tsx
@@ -12,6 +12,7 @@ import {
 } from '../types/plots';
 import PlotlyPlot, { PlotProps } from './PlotlyPlot';
 import { Layout } from 'plotly.js';
+import { some } from 'lodash';
 
 // in this example, the main variable is 'country'
 export interface BarplotProps
@@ -88,9 +89,24 @@ export default function Barplot({
     showticklabels: showIndependentAxisTickLabel,
   };
 
+  // if at least one value is 0 < x < 1 then these are probably fractions/proportions
+  // affects mouseover formatting only in logScale mode
+  // worst case is that mouseovers contain integers followed by .0000
+  const dataLooksFractional = useMemo(() => {
+    return some(
+      data.series.flatMap((series) => series.value),
+      (val) => val > 0 && val < 1
+    );
+  }, [data.series]);
+
   const dependentAxisLayout: Layout['yaxis'] | Layout['xaxis'] = {
     automargin: true,
     tickformat: dependentAxisLogScale ? ',.1r' : undefined, // comma-separated thousands, rounded to 1 significant digit
+    hoverformat: dependentAxisLogScale
+      ? dataLooksFractional
+        ? ',.4f'
+        : ',.0f'
+      : undefined,
     type: dependentAxisLogScale ? 'log' : 'linear',
     title: {
       text: dependentAxisLabel ? dependentAxisLabel : '',

--- a/src/plots/Histogram.tsx
+++ b/src/plots/Histogram.tsx
@@ -377,7 +377,7 @@ export default function Histogram({
   };
   const dependentAxisLayout: Layout['yaxis'] | Layout['xaxis'] = {
     type: dependentAxisLogScale ? 'log' : 'linear',
-    tickformat: ',.1r', // comma-separated thousands, rounded to 1 significant digit
+    tickformat: dependentAxisLogScale ? ',.1r' : undefined, // comma-separated thousands, rounded to 1 significant digit
     automargin: true,
     title: {
       text: dependentAxisLabel,

--- a/src/plots/Histogram.tsx
+++ b/src/plots/Histogram.tsx
@@ -17,7 +17,7 @@ import { NumberOrDate, NumberOrDateRange, NumberRange } from '../types/general';
 
 // Libraries
 import * as DateMath from 'date-arithmetic';
-import { sortBy, sortedUniqBy, orderBy } from 'lodash';
+import { sortBy, sortedUniqBy, orderBy, some } from 'lodash';
 
 // Components
 import PlotlyPlot, { PlotProps } from './PlotlyPlot';
@@ -375,9 +375,25 @@ export default function Histogram({
     range: plotlyIndependentAxisRange,
     tickfont: data.series.length ? {} : { color: 'transparent' },
   };
+
+  // if at least one bin.count is 0 < x < 1 then these are probably fractions/proportions
+  // affects mouseover formatting only in logScale mode
+  // worst case is that mouseovers contain integers followed by .0000
+  const dataLooksFractional = useMemo(() => {
+    return some(
+      data.series.flatMap((series) => series.bins.map((bin) => bin.count)),
+      (val) => val > 0 && val < 1
+    );
+  }, [data.series]);
+
   const dependentAxisLayout: Layout['yaxis'] | Layout['xaxis'] = {
     type: dependentAxisLogScale ? 'log' : 'linear',
     tickformat: dependentAxisLogScale ? ',.1r' : undefined, // comma-separated thousands, rounded to 1 significant digit
+    hoverformat: dependentAxisLogScale
+      ? dataLooksFractional
+        ? ',.4f'
+        : ',.0f'
+      : undefined,
     automargin: true,
     title: {
       text: dependentAxisLabel,


### PR DESCRIPTION
Spotted by @moontrip in https://github.com/VEuPathDB/web-eda/pull/254#issuecomment-891205601 


Actually we're not out of the woods yet.

As Dave points out, the mouse-over numbers are also affected by the rounding (now in logscale mode only).  This needs to be addressed through further digging into the Plotly manual.