### PR TITLE
basic styling changes

### DIFF
--- a/src/components/widgets/Button.tsx
+++ b/src/components/widgets/Button.tsx
@@ -52,7 +52,7 @@ export default function Button({
           disableElevation={true}
           style={{
             width: '100%',
-            color: textColor ? textColor : 'white',
+            color: textColor ? textColor : undefined,
           }}
           color="primary"
           onClick={onClick}

--- a/src/components/widgets/NumberAndDateInputs.tsx
+++ b/src/components/widgets/NumberAndDateInputs.tsx
@@ -93,7 +93,8 @@ function BaseInput({
 
   const classes = makeStyles({
     root: {
-      height: 32, // default height is 56 and is waaaay too tall
+      height: 36.5, // default height is 56 and is waaaay too tall
+      // 34.5 is the height of the reset button, but 36.5 lines up better
     },
   })();
 

--- a/src/components/widgets/NumberAndDateRangeInputs.tsx
+++ b/src/components/widgets/NumberAndDateRangeInputs.tsx
@@ -243,15 +243,14 @@ function BaseInput({
         )}
         {showClearButton && (
           <Button
-            type={'solid'}
+            type={'outlined'}
             text={clearButtonLabel}
             onClick={() => {
               setIsReceiving(false);
               setLocalRange(undefined);
             }}
             containerStyles={{
-              paddingLeft: '10px',
-              height: '20px',
+              paddingLeft: '20px',
             }}
           />
         )}


### PR DESCRIPTION
Fixes #118 

Goes with EDA PR https://github.com/VEuPathDB/web-eda/pull/270  

118 was basically fixed anyway, but I took the opportunity to fix some offensive styling issues

- reset buttons are less in your face
- x and y axis histogram filter controls now line up vertically
- histogram filter subsetting range control reset button now lines up (on FF at least)
- Histogram/Barplot viz controls are essentially unchanged - they were minimal and inoffensive anyway IMO.