### PR TITLE
Add color palette default and prop

### DIFF
--- a/src/plots/Barplot.tsx
+++ b/src/plots/Barplot.tsx
@@ -9,6 +9,7 @@ import {
   OrientationDefault,
   DependentAxisLogScaleAddon,
   DependentAxisLogScaleDefault,
+  ColorPaletteAddon,
 } from '../types/plots';
 import PlotlyPlot, { PlotProps } from './PlotlyPlot';
 import { Layout } from 'plotly.js';
@@ -20,7 +21,8 @@ export interface BarplotProps
     BarLayoutAddon<'overlay' | 'stack' | 'group'>,
     OrientationAddon,
     OpacityAddon,
-    DependentAxisLogScaleAddon {
+    DependentAxisLogScaleAddon,
+    ColorPaletteAddon {
   /** Label for independent axis. e.g. 'Country' */
   independentAxisLabel?: string;
   /** Label for dependent axis. Defaults to 'Count' */

--- a/src/plots/Boxplot.tsx
+++ b/src/plots/Boxplot.tsx
@@ -8,6 +8,7 @@ import {
   OpacityDefault,
   OrientationAddon,
   OrientationDefault,
+  ColorPaletteAddon,
 } from '../types/plots';
 import { NumberOrDateRange } from '../types/general';
 import { uniq, flatMap, at } from 'lodash';
@@ -15,7 +16,8 @@ import { uniq, flatMap, at } from 'lodash';
 export interface BoxplotProps
   extends PlotProps<BoxplotData>,
     OrientationAddon,
-    OpacityAddon {
+    OpacityAddon,
+    ColorPaletteAddon {
   /** label for independent axis */
   independentAxisLabel?: string;
   /** label for the (typically) y-axis, e.g. Wealth */

--- a/src/plots/Histogram.tsx
+++ b/src/plots/Histogram.tsx
@@ -12,6 +12,7 @@ import {
   BarLayoutAddon,
   DependentAxisLogScaleAddon,
   DependentAxisLogScaleDefault,
+  ColorPaletteAddon,
 } from '../types/plots';
 import { NumberOrDate, NumberOrDateRange, NumberRange } from '../types/general';
 
@@ -37,7 +38,8 @@ export interface HistogramProps
     OrientationAddon,
     OpacityAddon,
     BarLayoutAddon<'overlay' | 'stack'>,
-    DependentAxisLogScaleAddon {
+    DependentAxisLogScaleAddon,
+    ColorPaletteAddon {
   /** Label for independent axis. Defaults to `Bins`. */
   independentAxisLabel?: string;
   /** Label for dependent axis. Defaults to `Count`. */

--- a/src/plots/PlotlyPlot.tsx
+++ b/src/plots/PlotlyPlot.tsx
@@ -133,6 +133,7 @@ export default function PlotlyPlot<T>(
       displayLegend,
       legendTitle,
       title,
+      colorPalette,
     ]
   );
 

--- a/src/plots/PlotlyPlot.tsx
+++ b/src/plots/PlotlyPlot.tsx
@@ -8,7 +8,12 @@ import React, {
 import { PlotParams } from 'react-plotly.js';
 import { legendSpecification } from '../utils/plotly';
 import Spinner from '../components/Spinner';
-import { PlotLegendAddon, PlotSpacingAddon } from '../types/plots/addOns';
+import {
+  PlotLegendAddon,
+  PlotSpacingAddon,
+  ColorPaletteAddon,
+  ColorPaletteDefault,
+} from '../types/plots/addOns';
 import { LayoutLegendTitle } from '../types/plotly-omissions';
 // add d3.select
 import { select } from 'd3';
@@ -52,7 +57,7 @@ const Plot = lazy(() => import('react-plotly.js'));
  *
  */
 export default function PlotlyPlot<T>(
-  props: Omit<PlotProps<T>, 'data'> & PlotParams
+  props: Omit<PlotProps<T>, 'data'> & PlotParams & ColorPaletteAddon
 ) {
   const {
     title,
@@ -68,6 +73,7 @@ export default function PlotlyPlot<T>(
     maxLegendTextLength = 20,
     // expose data for applying legend ellipsis
     data,
+    colorPalette,
     ...plotlyProps
   } = props;
 
@@ -118,6 +124,7 @@ export default function PlotlyPlot<T>(
         ...(legendOptions ? legendSpecification(legendOptions) : {}),
       },
       autosize: true, // responds properly to enclosing div resizing (not to be confused with config.responsive)
+      colorway: colorPalette ?? ColorPaletteDefault,
     }),
     [
       plotlyProps.layout,

--- a/src/stories/plots/XYPlot.stories.tsx
+++ b/src/stories/plots/XYPlot.stories.tsx
@@ -594,7 +594,16 @@ const { dataSetProcess, yMin, yMax } = processInputData(
   'scatterplot',
   'markers',
   independentValueType,
-  dependentValueType
+  dependentValueType,
+  true
+);
+const { dataSetProcess: dataSetProcessDefaultColors } = processInputData(
+  dataSet,
+  'scatterplot',
+  'markers',
+  independentValueType,
+  dependentValueType,
+  false
 );
 // Case 1-2) checking line plot: raw data with line
 // const { dataSetProcess, yMin, yMax } = processInputData(
@@ -633,6 +642,35 @@ export const MultipleData = () => {
   return (
     <XYPlot
       data={dataSetProcess}
+      independentAxisLabel={independentAxisLabel}
+      dependentAxisLabel={dependentAxisLabel}
+      // not to use independentAxisRange
+      // independentAxisRange={[xMin, xMax]}
+      dependentAxisRange={{ min: yMin, max: yMax }}
+      title={plotTitle}
+      // width height is replaced with containerStyles
+      containerStyles={{
+        width: plotWidth,
+        height: plotHeight,
+      }}
+      // staticPlot is changed to interactive
+      interactive={true}
+      // check enable/disable legend and built-in controls
+      displayLegend={true}
+      displayLibraryControls={true}
+      // margin={{l: 50, r: 10, b: 20, t: 10}}
+      // add legend title
+      legendTitle={'legend title example'}
+      independentValueType={independentValueType}
+      dependentValueType={dependentValueType}
+    />
+  );
+};
+
+export const MultipleDataDefaultColors = () => {
+  return (
+    <XYPlot
+      data={dataSetProcessDefaultColors}
       independentAxisLabel={independentAxisLabel}
       dependentAxisLabel={dependentAxisLabel}
       // not to use independentAxisRange
@@ -772,7 +810,8 @@ function processInputData<T extends number | string>(
   modeValue: string,
   // send independentValueType & dependentValueType
   independentValueType: string,
-  dependentValueType: string
+  dependentValueType: string,
+  defineColors: boolean
 ) {
   // set fillAreaValue for densityplot
   const fillAreaValue = vizType === 'densityplot' ? 'toself' : '';
@@ -792,7 +831,7 @@ function processInputData<T extends number | string>(
   let yMin: number | string | undefined = 0;
   let yMax: number | string | undefined = 0;
 
-  // coloring: using plotly.js default colors
+  // coloring: using plotly.js default colors instead of web-components default palette
   const markerColors = [
     '31, 119, 180', //'#1f77b4',  // muted blue
     '255, 127, 14', //'#ff7f0e',  // safety orange
@@ -872,13 +911,20 @@ function processInputData<T extends number | string>(
             : 'scattergl', // for the raw data of the scatterplot
         fill: fillAreaValue,
         marker: {
-          color: 'rgba(' + markerColors[index] + ',0.7)',
+          color: defineColors
+            ? 'rgba(' + markerColors[index] + ',0.7)'
+            : undefined,
           // size: 6,
           // line: { color: 'rgba(' + markerColors[index] + ',0.7)', width: 2 },
         },
         // this needs to be here for the case of markers with line or lineplot.
         // always use spline?
-        line: { color: 'rgba(' + markerColors[index] + ',1)', shape: 'spline' },
+        line: {
+          color: defineColors
+            ? 'rgba(' + markerColors[index] + ',1)'
+            : undefined,
+          shape: 'spline',
+        },
       });
     }
   });
@@ -959,7 +1005,9 @@ function processInputData<T extends number | string>(
           : 'Smoothed mean',
         mode: 'lines', // no data point is displayed: only line
         line: {
-          color: 'rgba(' + markerColors[index] + ',1)',
+          color: defineColors
+            ? 'rgba(' + markerColors[index] + ',1)'
+            : undefined,
           shape: 'spline',
           width: 2,
         },
@@ -999,7 +1047,9 @@ function processInputData<T extends number | string>(
           : '95% Confidence interval',
         // this is better to be tozeroy, not tozerox
         fill: 'tozeroy',
-        fillcolor: 'rgba(' + markerColors[index] + ',0.2)',
+        fillcolor: defineColors
+          ? 'rgba(' + markerColors[index] + ',0.2)'
+          : undefined,
         // type: 'line',
         type: 'scattergl',
         // here, line means upper and lower bounds
@@ -1047,7 +1097,9 @@ function processInputData<T extends number | string>(
           : 'Best fit<br>R<sup>2</sup> = ' + el.r2,
         mode: 'lines', // no data point is displayed: only line
         line: {
-          color: 'rgba(' + markerColors[index] + ',1)',
+          color: defineColors
+            ? 'rgba(' + markerColors[index] + ',1)'
+            : undefined,
           shape: 'spline',
         },
         // use scattergl

--- a/src/types/plots/addOns.ts
+++ b/src/types/plots/addOns.ts
@@ -102,6 +102,7 @@ export type AvailableUnitsAddon =
 export type ColorPaletteAddon = {
   colorPalette?: string[];
 };
+/** Based on [Tol's muted colormap](https://personal.sron.nl/~pault/) */
 export const ColorPaletteDefault: string[] = [
   'rgb(136,34,85)',
   'rgb(136,204,238)',

--- a/src/types/plots/addOns.ts
+++ b/src/types/plots/addOns.ts
@@ -97,3 +97,18 @@ export type AvailableUnitsAddon =
       /** Currently selected unit. */
       selectedUnit?: never;
     };
+
+/** Color palette addon */
+export type ColorPaletteAddon = {
+  colorPalette?: string[];
+};
+export const ColorPaletteDefault: string[] = [
+  'rgb(136,34,85)',
+  'rgb(136,204,238)',
+  'rgb(153,153,51)',
+  'rgb(51,34,136)',
+  'rgb(68,170,153)',
+  'rgb(221,204,119)',
+  'rgb(204,102,119)',
+  'rgb(17,119,51)',
+];


### PR DESCRIPTION
Fixes https://github.com/VEuPathDB/web-components/issues/127

The color palette works for the following plots:

- Barplot
- Boxplot
- Histogram
- XYPlot

and doesn't work for the following plots:

- Heatmap (not qualitative)
- Mosaic
- Pie