### PR TITLE
Simplification of Histogram x-axis zooming and range selection fixes

### DIFF
--- a/src/components/plotControls/SelectedRangeControl.tsx
+++ b/src/components/plotControls/SelectedRangeControl.tsx
@@ -39,7 +39,15 @@ export default function SelectedRangeControl({
     : // use a custom validator when we don't want to
       // actually constrain the range between the bounds.
       useCallback((range?: NumberOrDateRange) => {
-        if (range && range?.min > range?.max) {
+        if (
+          range &&
+          (valueType === 'date'
+            ? // only compare the date part (one can be datetime, just-entered value is just a date)
+              (range.min as string).substring(0, 10) >
+              (range.max as string).substring(0, 10)
+            : range?.min > range?.max)
+        ) {
+          console.log(range);
           return {
             validity: false,
             message: 'Range start cannot be above range end',

--- a/src/components/plotControls/SelectedRangeControl.tsx
+++ b/src/components/plotControls/SelectedRangeControl.tsx
@@ -5,6 +5,7 @@ import {
 import LabelledGroup from '../widgets/LabelledGroup';
 import { NumberOrDateRange, NumberRange, DateRange } from '../../types/general';
 import { ContainerStylesAddon, ValueTypeAddon } from '../../types/plots';
+import { useCallback } from 'react';
 
 export interface SelectedRangeControlProps
   extends ValueTypeAddon,
@@ -15,8 +16,10 @@ export interface SelectedRangeControlProps
   selectedRange?: NumberOrDateRange;
   /** function to call upon selecting a range (in independent axis). Optional */
   onSelectedRangeChange?: (newRange?: NumberOrDateRange) => void;
-  /** Min and max allowed values for the selected range. Optional */
+  /** Min and max allowed values for the selected range. Used to auto-fill start or end. Optional */
   selectedRangeBounds?: NumberOrDateRange; // TO DO: handle DateRange too
+  /** Do we enforce the range bounds? Default is false */
+  enforceBounds?: boolean;
   /** show a clear button, optional, default is true */
   showClearButton?: boolean;
 }
@@ -27,9 +30,25 @@ export default function SelectedRangeControl({
   selectedRange,
   onSelectedRangeChange,
   selectedRangeBounds,
+  enforceBounds = false,
   showClearButton = true,
   containerStyles,
 }: SelectedRangeControlProps) {
+  const validator = enforceBounds
+    ? undefined
+    : // use a custom validator when we don't want to
+      // actually constrain the range between the bounds.
+      useCallback((range?: NumberOrDateRange) => {
+        if (range && range?.min > range?.max) {
+          return {
+            validity: false,
+            message: 'Range start cannot be above range end',
+          };
+        } else {
+          return { validity: true, message: '' };
+        }
+      }, []);
+
   return onSelectedRangeChange ? (
     <LabelledGroup label={label}>
       {valueType != null && valueType === 'date' ? (
@@ -40,6 +59,7 @@ export default function SelectedRangeControl({
           allowPartialRange={false}
           showClearButton={showClearButton}
           containerStyles={containerStyles}
+          validator={validator}
         />
       ) : (
         <NumberRangeInput
@@ -49,6 +69,7 @@ export default function SelectedRangeControl({
           allowPartialRange={false}
           showClearButton={showClearButton}
           containerStyles={containerStyles}
+          validator={validator}
         />
       )}
     </LabelledGroup>

--- a/src/components/widgets/NumberAndDateRangeInputs.tsx
+++ b/src/components/widgets/NumberAndDateRangeInputs.tsx
@@ -21,7 +21,8 @@ export type BaseProps<M extends NumberOrDateRange> = {
   /** Minimum and maximum allowed values for the user-inputted range. Optional. */
   rangeBounds?: M;
   /** Optional validator function. Should return {validity: true, message: ''} if value is allowed.
-   * If provided, rangeBounds and required will have no effect.
+   * If a validator is provided, `required` is no longer useful, and
+   * rangeBounds will only be used for auto-filling empty inputs.
    */
   validator?: (
     newRange?: NumberOrDateRange
@@ -80,9 +81,9 @@ function BaseInput({
   showClearButton = false,
   clearButtonLabel = 'Clear',
 }: BaseInputProps) {
-  if (validator && (required || rangeBounds))
+  if (validator && required)
     console.log(
-      'WARNING: NumberRangeInput or DateRangeInput will ignore props required and/or rangeBounds because validator was provided.'
+      'WARNING: NumberRangeInput or DateRangeInput will ignore `required` prop because validator was provided.'
     );
 
   const [focused, setFocused] = useState(false);

--- a/src/stories/plots/Histogram.stories.tsx
+++ b/src/stories/plots/Histogram.stories.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Story, Meta } from '@storybook/react/types-6-0';
 import {
+  NumberRange,
   NumberOrDateRange,
   NumberOrTimeDelta,
   TimeDelta,
@@ -82,9 +83,10 @@ const TemplateWithSelectedRangeControls: Story<Omit<HistogramProps, 'data'>> = (
   const [binWidth, setBinWidth] = useState<number>(500);
   const [selectedRange, setSelectedRange] = useState<NumberOrDateRange>();
   const [loading, setLoading] = useState<boolean>(true);
-  const [independentAxisRange, setIndependentAxisRange] = useState<
-    NumberOrDateRange
-  >();
+  const [
+    independentAxisRange,
+    setIndependentAxisRange,
+  ] = useState<NumberOrDateRange>();
 
   const handleBinWidthChange = async (newBinWidth: NumberOrTimeDelta) => {
     if (newBinWidth > 0) {
@@ -209,16 +211,16 @@ RepoMonthsNoControls.loaders = [
   }),
 ];
 
-const TemplateWithSelectedDateRangeControls: Story<Omit<
-  HistogramProps,
-  'data'
->> = (args) => {
+const TemplateWithSelectedDateRangeControls: Story<
+  Omit<HistogramProps, 'data'>
+> = (args) => {
   const [data, setData] = useState<HistogramData>();
   const [selectedRange, setSelectedRange] = useState<NumberOrDateRange>();
   const [loading, setLoading] = useState<boolean>(true);
-  const [independentAxisRange, setIndependentAxisRange] = useState<
-    NumberOrDateRange
-  >();
+  const [
+    independentAxisRange,
+    setIndependentAxisRange,
+  ] = useState<NumberOrDateRange>();
   const [binWidth, setBinWidth] = useState<NumberOrTimeDelta>({
     value: 1,
     unit: 'month',
@@ -344,4 +346,72 @@ export const EmptyDataLoading: Story<HistogramProps> = (args) => (
 EmptyDataLoading.args = {
   ...EmptyData.args,
   showSpinner: true,
+};
+
+const TemplateStaticWithRangeControls: Story<HistogramProps> = (args) => {
+  const [dependentAxisRange, setDependentAxisRange] = useState<NumberRange>();
+  const [
+    independentAxisRange,
+    setIndependentAxisRange,
+  ] = useState<NumberOrDateRange>();
+
+  const handleDependentAxisRangeChange = async (
+    newRange?: NumberOrDateRange
+  ) => {
+    setDependentAxisRange(newRange as NumberRange);
+  };
+
+  const handleIndependentAxisRangeChange = async (
+    newRange?: NumberOrDateRange
+  ) => {
+    setIndependentAxisRange(newRange);
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column' }}>
+      <Histogram
+        {...args}
+        independentAxisRange={independentAxisRange}
+        dependentAxisRange={dependentAxisRange}
+      />
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          justifyContent: 'space-around',
+        }}
+      >
+        <AxisRangeControl
+          label="Y-Axis Range"
+          range={dependentAxisRange}
+          onRangeChange={handleDependentAxisRangeChange}
+        />
+        <AxisRangeControl
+          label="X-Axis Range"
+          range={independentAxisRange}
+          onRangeChange={handleIndependentAxisRangeChange}
+        />
+      </div>
+    </div>
+  );
+};
+
+export const StaticDataWithRangeControls = TemplateStaticWithRangeControls.bind(
+  {}
+);
+StaticDataWithRangeControls.args = {
+  data: {
+    series: [
+      {
+        name: 'penguins',
+        bins: [42, 11, 99, 23, 7, 9].map((num, index) => ({
+          binStart: index + 1,
+          binEnd: index + 2,
+          binLabel: `${index + 1} to ${index + 2}`,
+          count: num,
+        })),
+      },
+    ],
+  },
+  interactive: true,
 };


### PR DESCRIPTION
Working on a simple Story for "truncated axis" stuff, I found that Histogram had a stupid feature where it wouldn't allow you to zoom in on the x-axis and thus hide some of the data that was given to the component.  I think partly the intention was to avoid chopping off bins (in the x-axis direction).  Histogram (and other plots) will have new truncation warnings to make this clear.

There was also a complicated modification to the first and last bins' `binStart` and `binEnd` for range selection purposes, involving a constraint prop called `selectedRangeBounds`.  People have commented that we don't need to constrain the selected range bounds, and I agree. 

So in this ticket I have

1. modified `SelectedRangeControl` to continue to take the `selectedRangeBounds` prop (for auto-fill purposes, when the user types just one number in), but no longer enforces the range bounds (you can type in age: -100 to +1000 if you want)
2. deprecated `selectedRangeBounds` (and related `isZoomed`) in `Histogram` - it was used to modify selected ranges that included the first or last bins.  It really wasn't worth all the complication.
3. introduced a "rounding" up or down of x-axis range coordinates so that no bin is ever chopped off when user zooms in
4. added a Histogram story with some simple static data - it demonstrates the "rounding" on the x-axis range: type 2.1 to 2.9 and it will make sure that you get the whole 2.0 to 3.0 bin.
5. selections on date variables: the end date has 1 day subtracted - see https://github.com/VEuPathDB/web-eda/pull/315 


