### PR TITLE
legend title ellipsis with tooltip

### DIFF
--- a/src/plots/PlotlyPlot.tsx
+++ b/src/plots/PlotlyPlot.tsx
@@ -192,7 +192,7 @@ export default function PlotlyPlot<T>(
           .text(legendTitle);
       }
     },
-    [storedLegendList]
+    [storedLegendList, legendTitle]
   );
 
   // set the number of characters to be displayed


### PR DESCRIPTION
This PR addressed [the issue at the web-eda, #332](https://github.com/VEuPathDB/web-eda/issues/332)

Tried to wrap lengthy legend title text at first. However it was found that the area of legend title did not allow multiple lines: wrapped texts were overlapped in the single line.

Thus, it was decided to use ellipsis with tooltip. A screenshot is attached as follows:

![legend-title-ellipsis](https://user-images.githubusercontent.com/12802305/131373842-dfd10c77-ba20-499d-94ae-25fe69459510.png)
