### PR TITLE
follow-ups for truncated axis - warning icon, plot line

### DIFF
--- a/src/components/widgets/Notification.tsx
+++ b/src/components/widgets/Notification.tsx
@@ -3,6 +3,7 @@ import { Typography } from '@material-ui/core';
 
 import { LIGHT_GREEN } from '../../constants/colors';
 import Button from './Button';
+import WarningIcon from '@material-ui/icons/Warning';
 
 export type NotificationProps = {
   /** The title of the notificatin. */
@@ -21,6 +22,8 @@ export type NotificationProps = {
   /** Additional styles to apply to the component's outer div.
    * Can also be used to override existing styles on the div. */
   containerStyles?: React.CSSProperties;
+  /** add showWarningIcon to show warning icon */
+  showWarningIcon?: boolean;
 };
 
 /** A notification widget to alert the user to some event. */
@@ -31,6 +34,7 @@ export default function Notification({
   occurences,
   color = LIGHT_GREEN,
   containerStyles = {},
+  showWarningIcon = false,
 }: NotificationProps) {
   return (
     <div
@@ -86,6 +90,12 @@ export default function Notification({
             lineHeight: '1.1em',
           }}
         >
+          {showWarningIcon && (
+            <WarningIcon
+              style={{ color: 'yellow', verticalAlign: 'middle' }}
+              fontSize="small"
+            />
+          )}
           {text}
         </span>
         <Button

--- a/src/components/widgets/Notification.tsx
+++ b/src/components/widgets/Notification.tsx
@@ -83,7 +83,7 @@ export default function Notification({
       <div style={{ display: 'flex', flexDirection: 'row' }}>
         <span
           style={{
-            paddingRight: 50,
+            paddingRight: 20,
             color: 'white',
             fontSize: 13,
             flexGrow: 2,
@@ -91,10 +91,13 @@ export default function Notification({
           }}
         >
           {showWarningIcon && (
-            <WarningIcon
-              style={{ color: 'yellow', verticalAlign: 'middle' }}
-              fontSize="small"
-            />
+            <>
+              <WarningIcon
+                style={{ color: 'yellow', verticalAlign: 'middle' }}
+                fontSize="small"
+              />
+              <span>&nbsp;</span>
+            </>
           )}
           {text}
         </span>

--- a/src/plots/Histogram.tsx
+++ b/src/plots/Histogram.tsx
@@ -352,10 +352,7 @@ const Histogram = makePlotlyPlotComponent(
       automargin: true,
       showgrid: false,
       zeroline: false,
-      showline:
-        orientation === 'vertical'
-          ? !axisTruncationConfig?.dependentAxis?.min
-          : !axisTruncationConfig?.independentAxis?.min,
+      showline: !axisTruncationConfig?.dependentAxis?.min,
       title: {
         text: independentAxisLabel,
       },
@@ -428,7 +425,7 @@ const Histogram = makePlotlyPlotComponent(
             extendedDependentAxisRange?.max,
           ].map((val) =>
             dependentAxisLogScale && val != null
-              ? val < 0
+              ? val <= 0
                 ? 0
                 : Math.log10(val as number)
               : val
@@ -436,10 +433,7 @@ const Histogram = makePlotlyPlotComponent(
         : [0, 10],
       dtick: dependentAxisLogScale ? 1 : undefined,
       tickfont: data.series.length ? {} : { color: 'transparent' },
-      showline:
-        orientation === 'vertical'
-          ? !axisTruncationConfig?.independentAxis?.min
-          : !axisTruncationConfig?.dependentAxis?.min,
+      showline: !axisTruncationConfig?.independentAxis?.min,
     };
 
     return {

--- a/src/plots/Histogram.tsx
+++ b/src/plots/Histogram.tsx
@@ -352,7 +352,10 @@ const Histogram = makePlotlyPlotComponent(
       automargin: true,
       showgrid: false,
       zeroline: false,
-      showline: false,
+      showline:
+        orientation === 'vertical'
+          ? !axisTruncationConfig?.dependentAxis?.min
+          : !axisTruncationConfig?.independentAxis?.min,
       title: {
         text: independentAxisLabel,
       },
@@ -433,7 +436,10 @@ const Histogram = makePlotlyPlotComponent(
         : [0, 10],
       dtick: dependentAxisLogScale ? 1 : undefined,
       tickfont: data.series.length ? {} : { color: 'transparent' },
-      showline: true,
+      showline:
+        orientation === 'vertical'
+          ? !axisTruncationConfig?.independentAxis?.min
+          : !axisTruncationConfig?.dependentAxis?.min,
     };
 
     return {


### PR DESCRIPTION
This is for follow-up items regarding truncated axis stuffs: see the [previous PR](https://github.com/VEuPathDB/web-eda/issues/98) and https://github.com/VEuPathDB/web-eda/issues/382. Will also make corresponding PR at web-eda.

I have discussed with Sheena about the appropriateness of new warning icon and she said it looked great.

![histogramfilter-warning1](https://user-images.githubusercontent.com/12802305/132390662-8d4e9a30-04ba-4fb3-aa50-e07ab0dd0b8e.png)

Also here are additional screenshot for X-axis line (depending on the presence of y-axis range, esp. yMin > 0 or not)

![truncated-xaxis1](https://user-images.githubusercontent.com/12802305/132390767-7eafc3d2-04a1-4f4b-befa-46be1fdfa4ea.png)

![truncated-xaxis2](https://user-images.githubusercontent.com/12802305/132390774-daaf90dc-b41c-4562-98e7-9b9b0c0e415d.png)
 