### PR TITLE
Remove width prop from ED Text

### DIFF
--- a/src/EntityDiagram/EntityDiagram.tsx
+++ b/src/EntityDiagram/EntityDiagram.tsx
@@ -222,7 +222,6 @@ export default function EntityDiagram({
           fontWeight: isHighlighted && selectedTextBold ? 'bold' : undefined,
         }}
         dy={isExpanded ? -shadingHeight : 0}
-        width={isExpanded ? nodeWidth - 40 : undefined}
       >
         {displayText}
       </Text>


### PR DESCRIPTION
Fixes https://github.com/VEuPathDB/web-eda/issues/388

I opted for removing the defined width from the ED Text component, as it seems with the box layout we're using we'll never want the text to wrap anyway. This should fix the styling for the length of entity names we currently have, but if we get much longer ones in the future, the text will start overflowing the box bounds.