### PR TITLE
Viz plot missing data styling

### DIFF
--- a/src/plots/Barplot.tsx
+++ b/src/plots/Barplot.tsx
@@ -71,7 +71,11 @@ const Barplot = makePlotlyPlotComponent(
               text: showValues ? el.value : undefined,
               textposition: showValues ? 'auto' : undefined,
               marker: {
-                ...(el.color ? { color: el.color } : {}),
+                color: el.color,
+                line: {
+                  width: el.borderColor ? 1 : 0,
+                  color: el.borderColor,
+                },
               },
             };
           } else {

--- a/src/plots/Boxplot.tsx
+++ b/src/plots/Boxplot.tsx
@@ -96,8 +96,14 @@ const Boxplot = makePlotlyPlotComponent('Boxplot', (props: BoxplotProps) => {
         jitter: 0.1, // should be dependent on the number of datapoints...?
         marker: {
           opacity: opacity,
-          color: d.color,
+          color: d.borderColor,
+          symbol: d.outlierSymbol ?? 'circle-open',
         },
+        line: {
+          width: 1,
+          color: d.borderColor,
+        },
+        fillcolor: d.color,
         ...orientationDependentProps,
         type: 'box',
         // `offsetgroup` somehow ensures that an overlay value with no data at all will

--- a/src/plots/Histogram.tsx
+++ b/src/plots/Histogram.tsx
@@ -119,7 +119,14 @@ const Histogram = makePlotlyPlotComponent(
           const binStarts = series.bins.map((bin) => bin.binStart);
           const binLabels = series.bins.map((bin) => bin.binLabel); // see TO DO: below
           const binCounts = series.bins.map((bin) => bin.count);
-          const binWidths = series.bins.map((bin) => {
+          const binWidths = series.bins.map((bin, index) => {
+            // Final bar needs to be a tiny bit narrower, especially
+            // if you are using white bars with borderColor,
+            // so that the right hand border is visible.
+            // Might be worth checking in future versions of Plotly if this
+            // was a bug or not.
+            const barWidthAdjust =
+              index === series.bins.length - 1 ? 0.999 : 1.0;
             if (data.valueType != null && data.valueType === 'date') {
               // date, needs to be in milliseconds
               // TO DO: bars seem very slightly too narrow at monthly resolution (multiplying by 1009 fixes it)
@@ -129,10 +136,15 @@ const Histogram = makePlotlyPlotComponent(
                   new Date(bin.binEnd as string),
                   'seconds',
                   false
-                ) * 1000
+                ) *
+                1000 *
+                barWidthAdjust
               );
             } else {
-              return (bin.binEnd as number) - (bin.binStart as number);
+              return (
+                ((bin.binEnd as number) - (bin.binStart as number)) *
+                barWidthAdjust
+              );
             }
           });
 
@@ -150,9 +162,11 @@ const Histogram = makePlotlyPlotComponent(
             text: showValues ? binCounts.map(String) : binLabels,
             textposition: showValues ? 'auto' : undefined,
             marker: {
-              ...(series.color
-                ? { color: series.color, line: { width: 1, color: '#d0d0d0' } }
-                : { line: { width: 1, color: 'white' } }),
+              color: series.color,
+              line: {
+                width: series.borderColor ? 1 : 0,
+                color: series.borderColor,
+              },
             },
             offset: 0,
             width: binWidths,

--- a/src/plots/Histogram.tsx
+++ b/src/plots/Histogram.tsx
@@ -150,7 +150,9 @@ const Histogram = makePlotlyPlotComponent(
             text: showValues ? binCounts.map(String) : binLabels,
             textposition: showValues ? 'auto' : undefined,
             marker: {
-              ...(series.color ? { color: series.color } : {}),
+              ...(series.color
+                ? { color: series.color, line: { width: 1, color: '#d0d0d0' } }
+                : { line: { width: 1, color: 'white' } }),
             },
             offset: 0,
             width: binWidths,

--- a/src/types/plots/barplot.ts
+++ b/src/types/plots/barplot.ts
@@ -4,7 +4,11 @@ export type BarplotData = {
     name: string;
     /** The color of the data. Optional. */
     color?: string;
+    /** The color of the bar outline. Optional. */
+    borderColor?: string;
+    /** The values that make the height of the bars */
     value: number[];
+    /** The x-axis tick labels for the bars */
     label: string[]; // e.g. India, Pakistan, Mali
   }[];
 };

--- a/src/types/plots/boxplot.ts
+++ b/src/types/plots/boxplot.ts
@@ -17,8 +17,12 @@ export type BoxplotData = {
   label: string[];
   /** legend name */
   name?: string;
-  /** color for this box */
+  /** color for this box. Optional. */
   color?: string;
+  /** color for the box border. Optional. */
+  borderColor?: string;
+  /** symbol to use for outlier markers. Optional. Default is 'circle-open' */
+  outlierSymbol?: 'x' | 'circle-open';
   /** optional complete data (not recommended for huge datasets) */
   rawData?: number[][] | string[][];
   /** outliers: data points outside upper and lower whiskers/fences (optional) */

--- a/src/types/plots/histogram.ts
+++ b/src/types/plots/histogram.ts
@@ -25,6 +25,8 @@ export type HistogramDataSeries = {
   name: string;
   /** The color of the series. Optional. */
   color?: string;
+  /** The color for the outline of the bars. Optional. */
+  borderColor?: string;
   /** Bins of data in the series. */
   bins: HistogramBin[];
   /** Summary stats for the series */


### PR DESCRIPTION
These are mostly minor styling changes required to implement https://github.com/VEuPathDB/web-eda/issues/335 

The one possibly contentious change is the 0.999 fudge factor in Histogram.tsx - which was needed so that the right-hand edge of the final no-data histogram bar was drawn properly.

Storybook stories have been checked and hopefully unchanged, visually.  Though there is no story to demo the new borderColor and outlierMarker props.  Bad!