### PR TITLE
long independent axis tick label

### DIFF
--- a/src/plots/Barplot.tsx
+++ b/src/plots/Barplot.tsx
@@ -12,7 +12,9 @@ import {
 } from '../types/plots';
 import { makePlotlyPlotComponent, PlotProps } from './PlotlyPlot';
 import { Layout } from 'plotly.js';
-import { some } from 'lodash';
+import { some, uniq, flatMap } from 'lodash';
+// util functions for handling long tick labels with ellipsis
+import { axisTickLableEllipsis } from '../utils/axis-tick-label-ellipsis';
 
 // in this example, the main variable is 'country'
 export interface BarplotProps
@@ -51,6 +53,23 @@ const Barplot = makePlotlyPlotComponent(
     dependentAxisLogScale = DependentAxisLogScaleDefault,
     ...restProps
   }: BarplotProps) => {
+    // set tick label Length for ellipsis
+    const maxIndependentTickLabelLength = 20;
+
+    // get the order of the provided category values (labels shown along x-axis)
+    // get them in the given order, and trivially unique-ify them, if traces have different values
+    // this will also be used as tooltip text for axis tick labels
+    const categoryOrder = useMemo(
+      () => uniq(flatMap(data.series, (d) => d.label)),
+      [data]
+    );
+
+    // change categoriOrder to have ellipsis
+    const categoryOrderEllipsis = useMemo(
+      () => axisTickLableEllipsis(categoryOrder, maxIndependentTickLabelLength),
+      [data, categoryOrder]
+    );
+
     // Transform `data` into a Plot.ly friendly format.
     const plotlyFriendlyData: PlotParams['data'] = useMemo(
       () =>
@@ -62,8 +81,25 @@ const Barplot = makePlotlyPlotComponent(
           // check data exist
           if (el.label && el.value) {
             return {
-              x: orientation === 'vertical' ? el.label : el.value,
-              y: orientation === 'vertical' ? el.value : el.label,
+              // mapping data based on categoryOrder and categoryOrderEllipsis
+              x:
+                orientation === 'vertical'
+                  ? el.label.map((d: string) => {
+                      const findIndexValue = categoryOrder.findIndex(
+                        (element) => element === d
+                      );
+                      return categoryOrderEllipsis[findIndexValue];
+                    })
+                  : el.value,
+              y:
+                orientation === 'vertical'
+                  ? el.value
+                  : el.label.map((d: string) => {
+                      const findIndexValue = categoryOrder.findIndex(
+                        (element) => element === d
+                      );
+                      return categoryOrderEllipsis[findIndexValue];
+                    }),
               name: el.name, // legend name
               orientation: orientation === 'vertical' ? 'v' : 'h',
               opacity: calculatedOpacity,
@@ -136,8 +172,10 @@ const Barplot = makePlotlyPlotComponent(
     return {
       data: plotlyFriendlyData,
       layout,
-      //DKDK handling long independent axis tick label
+      // handling long independent axis tick label
       plotName: 'barplot',
+      // original independent axis tick labels for tooltip
+      storedIndependentAxisTickLabel: categoryOrder,
       ...restProps,
     };
   }

--- a/src/plots/Barplot.tsx
+++ b/src/plots/Barplot.tsx
@@ -136,6 +136,8 @@ const Barplot = makePlotlyPlotComponent(
     return {
       data: plotlyFriendlyData,
       layout,
+      //DKDK handling long independent axis tick label
+      plotName: 'barplot',
       ...restProps,
     };
   }

--- a/src/plots/Barplot.tsx
+++ b/src/plots/Barplot.tsx
@@ -85,10 +85,10 @@ const Barplot = makePlotlyPlotComponent(
               x:
                 orientation === 'vertical'
                   ? el.label.map((d: string) => {
-                      const findIndexValue = categoryOrder.findIndex(
+                      const foundIndexValue = categoryOrder.findIndex(
                         (element) => element === d
                       );
-                      return categoryOrderEllipsis[findIndexValue];
+                      return categoryOrderEllipsis[foundIndexValue];
                     })
                   : el.value,
               y:
@@ -172,8 +172,6 @@ const Barplot = makePlotlyPlotComponent(
     return {
       data: plotlyFriendlyData,
       layout,
-      // handling long independent axis tick label
-      plotName: 'barplot',
       // original independent axis tick labels for tooltip
       storedIndependentAxisTickLabel: categoryOrder,
       ...restProps,

--- a/src/plots/Boxplot.tsx
+++ b/src/plots/Boxplot.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Layout } from 'plotly.js';
+import React, { useMemo } from 'react';
+import { Layout, Datum } from 'plotly.js';
 import { PlotParams } from 'react-plotly.js';
 import { makePlotlyPlotComponent, PlotProps } from './PlotlyPlot';
 import {
@@ -10,7 +10,7 @@ import {
   OrientationDefault,
 } from '../types/plots';
 import { NumberOrDateRange } from '../types/general';
-import { uniq, flatMap, at } from 'lodash';
+import { uniq, flatMap, at, omitBy, reduce, set } from 'lodash';
 
 export interface BoxplotProps
   extends PlotProps<BoxplotData>,
@@ -50,6 +50,9 @@ const Boxplot = makePlotlyPlotComponent('Boxplot', (props: BoxplotProps) => {
     dependentValueType = 'number',
     ...restProps
   } = props;
+
+  //DKDK
+  const maxIndependentTickLableLength = 20;
 
   // get the order of the provided category values (labels shown along x-axis)
   // get them in the given order, and trivially unique-ify them, if traces have different values
@@ -130,7 +133,16 @@ const Boxplot = makePlotlyPlotComponent('Boxplot', (props: BoxplotProps) => {
       showticklabels: showIndependentAxisTickLabel,
       // part 3 of the hack:
       categoryorder: 'array',
-      categoryarray: categoryOrder,
+      //DKDK DKDKDK this was the culprit!!!
+      categoryarray: categoryOrder.map((element: any) => {
+        return ((element as string) || '').length >
+          maxIndependentTickLableLength
+          ? ((element as string) || '').substring(
+              0,
+              maxIndependentTickLableLength
+            ) + '...'
+          : element;
+      }),
     },
     [dependentAxis]: {
       automargin: true,
@@ -151,8 +163,13 @@ const Boxplot = makePlotlyPlotComponent('Boxplot', (props: BoxplotProps) => {
   };
 
   return {
+    //DKDK
     data,
+    // data: finalData as PlotParams['data'],
     layout,
+    //DKDK handling long independent axis tick label
+    plotName: 'boxplot',
+    //DKDK need to send full axis tick label
     ...restProps,
   };
 });

--- a/src/plots/Boxplot.tsx
+++ b/src/plots/Boxplot.tsx
@@ -85,10 +85,10 @@ const Boxplot = makePlotlyPlotComponent('Boxplot', (props: BoxplotProps) => {
         // mapping data based on categoryOrder and categoryOrderEllipsis
         [independentAxisName]: at(d.label, definedDataIndices).map(
           (d: string) => {
-            const findIndexValue = categoryOrder.findIndex(
+            const foundIndexValue = categoryOrder.findIndex(
               (element: string) => element === d
             );
-            return categoryOrderEllipsis[findIndexValue];
+            return categoryOrderEllipsis[foundIndexValue];
           }
         ),
         [dependentAxisName]:
@@ -178,8 +178,6 @@ const Boxplot = makePlotlyPlotComponent('Boxplot', (props: BoxplotProps) => {
   return {
     data,
     layout,
-    // handling long independent axis tick label
-    plotName: 'boxplot',
     // original independent axis tick labels for tooltip
     storedIndependentAxisTickLabel: categoryOrder,
     ...restProps,

--- a/src/plots/PlotlyPlot.tsx
+++ b/src/plots/PlotlyPlot.tsx
@@ -60,8 +60,6 @@ export interface PlotProps<T> extends ColorPaletteAddon {
   spacingOptions?: PlotSpacingAddon;
   /** maximum number of characters for legend ellipsis */
   maxLegendTextLength?: number;
-  /** plot name: this will be used for handling long independent axis tick label (only for barplot and boxplot) */
-  plotName?: string;
   /** original independent axis tick labels as data is changed at each component (barplot and boxplot)*/
   storedIndependentAxisTickLabel?: string[];
 }
@@ -96,8 +94,6 @@ function PlotlyPlot<T>(
     maxLegendTextLength = 20,
     // expose data for applying legend ellipsis
     data,
-    // handling long independent axis tick label only for barplot and boxplot
-    plotName,
     // original independent axis tick labels for tooltip text
     storedIndependentAxisTickLabel,
     colorPalette = ColorPaletteDefault,
@@ -229,8 +225,8 @@ function PlotlyPlot<T>(
 
       // independent axis tick label for barplot and boxplot
       if (
-        plotName != null &&
-        (plotName === 'barplot' || plotName === 'boxplot')
+        storedIndependentAxisTickLabel != null &&
+        storedIndependentAxisTickLabel.length > 0
       ) {
         // remove pre-existing xtick.title
         select(graphDiv)
@@ -257,7 +253,12 @@ function PlotlyPlot<T>(
           });
       }
     },
-    [storedLegendList, legendTitle, storedIndependentAxisTickLabel]
+    [
+      storedLegendList,
+      legendTitle,
+      maxLegendTitleTextLength,
+      storedIndependentAxisTickLabel,
+    ]
   );
 
   const finalData = useMemo(() => {

--- a/src/utils/axis-tick-label-ellipsis.ts
+++ b/src/utils/axis-tick-label-ellipsis.ts
@@ -19,21 +19,23 @@ export const axisTickLableEllipsis = (
   // looping object to map data's label and label with ellipsis
   Object.entries(duplicateIndexValue).forEach((entry: any) => {
     const [key, value] = entry;
-    // add space for duplicates
-    let addDot = ' ';
-    let multiStr = '';
     // starting from i = 1 so that the first item is not changed
     for (let i = 1; i < (value as number[]).length; i++) {
-      multiStr += addDot;
+      // add incremental space(s) for duplicates
       categoryOrderEllipsis[value[i]] =
-        categoryOrderEllipsis[value[i]] + multiStr;
+        categoryOrderEllipsis[value[i]] + ' '.repeat(i);
     }
   });
 
   return categoryOrderEllipsis;
 };
 
-// A function to return object comprised of duplicates and indices
+/**
+ *  Returning an object comprised of of duplicate(s) and corresponding index array
+ *    Input: an array that has duplicate elements
+ *    Output: an object, e.g.,
+ *      { 'duplicate element 1': [0, 1, 3], 'duplicate element 2': [5, 7], ... }
+ */
 const getDuplicates = (arr: string[]) => {
   var duplicates: any = {};
   for (var i = 0; i < arr.length; i++) {

--- a/src/utils/axis-tick-label-ellipsis.ts
+++ b/src/utils/axis-tick-label-ellipsis.ts
@@ -37,8 +37,8 @@ export const axisTickLableEllipsis = (
  *      { 'duplicate element 1': [0, 1, 3], 'duplicate element 2': [5, 7], ... }
  */
 const getDuplicates = (arr: string[]) => {
-  var duplicates: any = {};
-  for (var i = 0; i < arr.length; i++) {
+  const duplicates: Record<string, number[]> = {};
+  for (let i = 0; i < arr.length; i++) {
     if (duplicates.hasOwnProperty(arr[i])) {
       duplicates[arr[i]].push(i);
     } else if (arr.lastIndexOf(arr[i]) !== i) {

--- a/src/utils/axis-tick-label-ellipsis.ts
+++ b/src/utils/axis-tick-label-ellipsis.ts
@@ -1,0 +1,47 @@
+/**
+ * A util functions for handling long tick labels
+ */
+
+export const axisTickLableEllipsis = (
+  categoryOrder: string[],
+  maxIndependentTickLabelLength: number
+) => {
+  // make array for tick label with ellipsis
+  const categoryOrderEllipsis = categoryOrder.map((element) => {
+    return (element || '').length > maxIndependentTickLabelLength
+      ? (element || '').substring(0, maxIndependentTickLabelLength) + '...'
+      : element;
+  });
+
+  // identify duplicate element and duplicate indices in the array
+  const duplicateIndexValue = getDuplicates(categoryOrderEllipsis);
+
+  // looping object to map data's label and label with ellipsis
+  Object.entries(duplicateIndexValue).forEach((entry: any) => {
+    const [key, value] = entry;
+    // add space for duplicates
+    let addDot = ' ';
+    let multiStr = '';
+    // starting from i = 1 so that the first item is not changed
+    for (let i = 1; i < (value as number[]).length; i++) {
+      multiStr += addDot;
+      categoryOrderEllipsis[value[i]] =
+        categoryOrderEllipsis[value[i]] + multiStr;
+    }
+  });
+
+  return categoryOrderEllipsis;
+};
+
+// A function to return object comprised of duplicates and indices
+const getDuplicates = (arr: string[]) => {
+  var duplicates: any = {};
+  for (var i = 0; i < arr.length; i++) {
+    if (duplicates.hasOwnProperty(arr[i])) {
+      duplicates[arr[i]].push(i);
+    } else if (arr.lastIndexOf(arr[i]) !== i) {
+      duplicates[arr[i]] = [i];
+    }
+  }
+  return duplicates;
+};


### PR DESCRIPTION
This is an initial draft PR that works for barplot: here is [the issue at web-eda](https://github.com/VEuPathDB/web-eda/issues/328)
Unlike the initial thought regarding this work, a possible solution I had suggested before turned out to be inappropriate for this task. Thus, switched back to an approach similar to legend/legend title's ellipsis with tooltip. However, the approach did not work for this task directly, so spent quite a long time to figure out the reason. It turned out that the tick label should have pointer-events attribute to activate tooltip.

Initial impression is that this works fine so will try to do the same thing for boxplot and see. Cleanup is not done yet either.