### PR TITLE
Changed focus behaviour of birds eye plot annotations.

### DIFF
--- a/src/plots/BirdsEyePlot.tsx
+++ b/src/plots/BirdsEyePlot.tsx
@@ -148,11 +148,8 @@ export default function BirdsEyePlot({
   };
 
   return (
-    <div style={{ ...containerStyles, cursor: 'pointer' }}>
-      <div
-        onMouseOver={() => setFocused(true)}
-        onMouseOut={() => setFocused(false)}
-      >
+    <div style={{ ...containerStyles }} onMouseLeave={() => setFocused(false)}>
+      <div style={{ cursor: 'pointer' }} onMouseEnter={() => setFocused(true)}>
         <PlotlyPlot
           data={plotlyFriendlyData}
           layout={layout}

--- a/src/plots/BirdsEyePlot.tsx
+++ b/src/plots/BirdsEyePlot.tsx
@@ -148,17 +148,18 @@ export default function BirdsEyePlot({
   };
 
   return (
-    <div
-      style={{ ...containerStyles, cursor: 'pointer' }}
-      onMouseOver={() => setFocused(true)}
-      onMouseOut={() => setFocused(false)}
-    >
-      <PlotlyPlot
-        data={plotlyFriendlyData}
-        layout={layout}
-        containerStyles={{ height: '100px' }}
-        {...restProps}
-      />
+    <div style={{ ...containerStyles, cursor: 'pointer' }}>
+      <div
+        onMouseOver={() => setFocused(true)}
+        onMouseOut={() => setFocused(false)}
+      >
+        <PlotlyPlot
+          data={plotlyFriendlyData}
+          layout={layout}
+          containerStyles={{ height: '100px' }}
+          {...restProps}
+        />
+      </div>
       <div
         style={{
           display: 'flex',


### PR DESCRIPTION
Addresses QA feedback for https://github.com/VEuPathDB/web-eda/issues/234

<s>This is so trivial I'm going to merge it without review.</s>

Update: less trivial fix now.  Inner div now sets focus, outer div cancels it.
Had to use onMouseLeave() for bubbling reasons.  For symmetry I used onMouseEnter() too.

I would appreciate just 1/3 reviews please!

Can be tested in Storybook :-)

