### PR TITLE
long y-axis title handled by ellipsis and tooltip

### DIFF
--- a/src/plots/PlotlyPlot.tsx
+++ b/src/plots/PlotlyPlot.tsx
@@ -199,7 +199,10 @@ function PlotlyPlot<T>(
   }, [data]);
 
   // keep dependent axis title for tooltip text
-  const originalDependentAxisTitle = plotlyProps?.layout?.yaxis?.title;
+  const originalDependentAxisTitle = useMemo(
+    () => plotlyProps?.layout?.yaxis?.title,
+    [plotlyProps?.layout?.yaxis?.title]
+  );
 
   // ellipsis with tooltip for legend, legend title, and independent axis tick labels
   const onUpdate = useCallback(
@@ -295,6 +298,7 @@ function PlotlyPlot<T>(
       legendTitle,
       maxLegendTitleTextLength,
       storedIndependentAxisTickLabel,
+      originalDependentAxisTitle,
     ]
   );
 

--- a/src/plots/PlotlyPlot.tsx
+++ b/src/plots/PlotlyPlot.tsx
@@ -102,6 +102,8 @@ function PlotlyPlot<T>(
 
   // set max legend title length for ellipsis
   const maxLegendTitleTextLength = maxLegendTextLength + 5;
+  // set max dependent axis title length for ellipsis
+  const maxDependentAxisTitleTextLength = 50;
 
   /** This is used to ensure toImage is called after the plot has been created */
   const sharedPlotCreation = useMemo(
@@ -134,6 +136,15 @@ function PlotlyPlot<T>(
         fixedrange: true,
         linewidth: 1,
         linecolor: 'black',
+        // change long delendent axis title with ellipsis
+        title:
+          ((plotlyProps?.layout?.yaxis?.title as string) || '').length >
+          maxDependentAxisTitleTextLength
+            ? ((plotlyProps?.layout?.yaxis?.title as string) || '').substring(
+                0,
+                maxDependentAxisTitleTextLength
+              ) + '...'
+            : plotlyProps?.layout?.yaxis?.title,
       },
       title: {
         text: title,
@@ -186,6 +197,9 @@ function PlotlyPlot<T>(
       return [];
     }
   }, [data]);
+
+  // keep dependent axis title for tooltip text
+  const originalDependentAxisTitle = plotlyProps?.layout?.yaxis?.title;
 
   // ellipsis with tooltip for legend, legend title, and independent axis tick labels
   const onUpdate = useCallback(
@@ -251,6 +265,29 @@ function PlotlyPlot<T>(
               ? (storedIndependentAxisTickLabel[i] as string)
               : '';
           });
+      }
+
+      // handling dependent axis title with ellipsis & tooltip
+      if (
+        originalDependentAxisTitle != null &&
+        (originalDependentAxisTitle as string).length >
+          maxDependentAxisTitleTextLength
+      ) {
+        // remove duplicate svg:title
+        select(graphDiv)
+          .select('.plot-container svg.main-svg g.infolayer g.g-ytitle')
+          .selectAll('title')
+          .remove();
+
+        // add tooltip
+        select(graphDiv)
+          .select(
+            '.plot-container svg.main-svg g.infolayer g.g-ytitle text.ytitle'
+          )
+          // need this attribute for tooltip of dependent axis title!
+          .attr('pointer-events', 'all')
+          .append('svg:title')
+          .text(originalDependentAxisTitle as string);
       }
     },
     [


### PR DESCRIPTION
This PR will address the issue, [#395 at web-eda](https://github.com/VEuPathDB/web-eda/issues/395)

A long y-axis title is now handled by ellipsis and tooltip. Currently the max number of characters for y-axis title is set to 50 based on eye test 😃 

A screenshot is shown as follows: somehow backend data service seems not to work correctly so no plot is made, however, it is just okay to see the implementation anyway. Just FYI, this was captured using d-falke data service, GEMS1A Case Control study, and Mosaic 2x2 table plot.

![test-long-yAxis-title](https://user-images.githubusercontent.com/12802305/135356352-fd62ddd9-b25a-409e-ad82-7aada2f555f1.png)
