### PR TITLE
add expanded entity diagram class

### DIFF
--- a/src/EntityDiagram/EntityDiagram.tsx
+++ b/src/EntityDiagram/EntityDiagram.tsx
@@ -331,7 +331,7 @@ export default function EntityDiagram({
   }
 
   return (
-    <div className={isExpanded ? '' : 'mini-diagram'}>
+    <div className={isExpanded ? 'expanded-diagram' : 'mini-diagram'}>
       <svg width={size.width} height={size.height}>
         <defs>
           <marker

--- a/src/EntityDiagram/diagram.css
+++ b/src/EntityDiagram/diagram.css
@@ -2,6 +2,10 @@
   position: absolute;
 }
 
+.expanded-diagram {
+  margin: auto;
+}
+
 .expanded-diagram-enter {
   opacity: 0;
   transform: scale(-0.5);

--- a/src/EntityDiagram/diagram.css
+++ b/src/EntityDiagram/diagram.css
@@ -4,6 +4,7 @@
 
 .expanded-diagram {
   margin: auto;
+  max-width: 100vw;
 }
 
 .expanded-diagram-enter {


### PR DESCRIPTION
With web-eda PR [#504](https://github.com/VEuPathDB/web-eda/pull/504), resolves web-eda issue [#428](https://github.com/VEuPathDB/web-eda/issues/428)

This PR adds class name `expanded-diagram` to the entity diagram for easier styling.