### PR TITLE
Fixed two mouse-over issues for histogram and bar plot

### DIFF
--- a/src/plots/Barplot.tsx
+++ b/src/plots/Barplot.tsx
@@ -113,6 +113,10 @@ const Barplot = makePlotlyPlotComponent(
                   color: el.borderColor,
                 },
               },
+              hovertemplate: el.value.map(
+                (value: number, index: number) =>
+                  `${value}<br />${el.label[index]}<br />${el.name}<extra></extra>`
+              ),
             };
           } else {
             return {};
@@ -171,6 +175,7 @@ const Barplot = makePlotlyPlotComponent(
           ? dependentAxisLayout
           : independentAxisLayout,
       barmode: barLayout,
+      hovermode: 'closest',
     };
 
     return {

--- a/src/plots/Histogram.tsx
+++ b/src/plots/Histogram.tsx
@@ -181,6 +181,10 @@ const Histogram = makePlotlyPlotComponent(
                 opacity: 1,
               },
             },
+            hovertemplate: binCounts.map(
+              (count, index) =>
+                `${count}<br />${binLabels[index]}<br />${series.name}<extra></extra>`
+            ),
           };
         }),
       [data, orientation, calculatedBarOpacity, selectedRange, showValues]
@@ -470,6 +474,7 @@ const Histogram = makePlotlyPlotComponent(
             ? dependentAxisLayout
             : independentAxisLayout,
         barmode: barLayout,
+        hovermode: 'closest',
       },
       data: plotlyFriendlyData,
       onSelected: handleSelectedRange,


### PR DESCRIPTION
Resolves #220 
Resolves #219 

Switched over to `hovermode: 'closest'` and added custom `hoverformat` text and killed two birds with one stone :-)