### PR TITLE
define traceorder for histogram filter plot's legend order

### DIFF
--- a/src/types/plots/addOns.ts
+++ b/src/types/plots/addOns.ts
@@ -24,6 +24,8 @@ export type PlotLegendAddon = {
     size: number;
     color: string;
   };
+  /** legend traceorder (for histogram filter) */
+  traceorder?: 'reversed' | 'grouped' | 'normal' | undefined;
 };
 
 /** Specification to control plot margins and padding. */

--- a/src/utils/plotly/legendSpecification.ts
+++ b/src/utils/plotly/legendSpecification.ts
@@ -55,5 +55,7 @@ export default (args: PlotLegendAddon): Partial<Legend> => {
     y: yPosition,
     yanchor: 'auto',
     font: args.font,
+    // define traceorder
+    traceorder: args.traceorder,
   };
 };


### PR DESCRIPTION
This PR is for changing the legend order of the histogram filter plot: showing Subset.. at first and then All... in the next. 
Initially, spent time implementing `legendrank` approach. It worked at tests through Codepen, but did not work at our dev env. Finally figured it out that the legendrank was recently added in the plotly.js (since v2.1.0), while we are using older version (v1.54.1). It would have been more straightforward to use legendrank in this case, but due to current limitation, I have settled down to use traceorder approach in this case: simply put, just reversing the order of legend that is controlled by a prop. 