### PR TITLE
toggle text gray for disabled, else black

### DIFF
--- a/src/components/widgets/Switch.tsx
+++ b/src/components/widgets/Switch.tsx
@@ -3,7 +3,7 @@ import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
 import { Typography } from '@material-ui/core';
 import MaterialSwitch from '@material-ui/core/Switch';
 
-import { DARK_GRAY, LIGHT_BLUE, MEDIUM_GRAY } from '../../constants/colors';
+import { LIGHT_BLUE, MEDIUM_GRAY } from '../../constants/colors';
 
 export type SwitchProps = {
   /** Optional label for widget. */
@@ -62,7 +62,7 @@ export default function Switch({
         <Typography
           variant="button"
           style={{
-            color: DARK_GRAY,
+            color: disabled ? MEDIUM_GRAY : 'rgb(0, 0, 0)',
             ...(labelPosition === 'after'
               ? { paddingLeft: 5 }
               : { paddingRight: 5 }),


### PR DESCRIPTION
Resolves web-eda [#574](https://github.com/VEuPathDB/web-eda/issues/574)

When toggles are disabled, their text will now be in MEDIUM_GRAY. Otherwise, their text will be black.

Also considered making the text a dark gray when enabled, to better match the toggle itself. Would require adding a fourth gray to our collection, so unless we have lots of support to add another gray we can just use black.

<img width="1298" alt="Screen Shot 2021-11-03 at 2 32 06 PM" src="https://user-images.githubusercontent.com/11710234/140171369-a1c8130c-e8d8-4fa7-9881-dbe752b536f1.png">

