### PR TITLE
Facet container

### DIFF
--- a/src/plots/FacetedPlot.tsx
+++ b/src/plots/FacetedPlot.tsx
@@ -1,46 +1,39 @@
 import React from 'react';
-import { isFaceted } from '../types/guards';
 import { FacetedData } from '../types/plots';
 import { PlotProps } from './PlotlyPlot';
 
 export interface FacetedPlotProps<D, P extends PlotProps<D>> {
   data?: FacetedData<D>;
-  component: React.ElementType<P>;
+  component: React.ComponentType<P>;
   props: P;
 }
 
 export default function FacetedPlot<D, P extends PlotProps<D>>(
   props: FacetedPlotProps<D, P>
 ) {
-  const { data, component, props: componentProps } = props;
-
-  const Component = component as React.ElementType; // casting seems to be needed if using component: React.ElementType<P>; above
-
-  // return a regular plot component if the data isn't faceted.
-  if (!isFaceted(data)) {
-    throw new Error('Unfaceted data provided to FacetedPlot');
-  } else {
-    return (
-      <div>
-        <h2>{componentProps.title}</h2>
-        <div style={{ display: 'flex', flexDirection: 'row' }}>
-          {data?.facets.map(({ data, label }, index) => (
-            <Component
-              {...componentProps}
-              key={index}
-              data={data}
-              title={label}
-              containerStyles={{
-                width: '300px',
-                height: '300px',
-                border: '3px dashed gray',
-              }}
-              displayLegend={false}
-              interactive={false}
-            />
-          ))}
-        </div>
+  const { data, component: Component, props: componentProps } = props;
+  return (
+    <div>
+      <h2>{componentProps.title}</h2>
+      <div
+        style={{
+          display: 'grid',
+          gridAutoFlow: 'column',
+          width: '100%',
+          overflow: 'auto',
+        }}
+      >
+        {data?.facets.map(({ data, label }, index) => (
+          <Component
+            {...componentProps}
+            key={index}
+            data={data}
+            title={label}
+            displayLegend={false}
+            interactive={false}
+          />
+        ))}
       </div>
-    );
-  }
+    </div>
+  );
 }

--- a/src/stories/plots/PiePlot.stories.tsx
+++ b/src/stories/plots/PiePlot.stories.tsx
@@ -188,6 +188,186 @@ const facetedData: FacetedData<PiePlotData> = {
         ],
       },
     },
+    {
+      label: 'indoors',
+      data: {
+        slices: [
+          {
+            value: 25,
+            label: 'dogs',
+          },
+          {
+            value: 10,
+            label: 'cats',
+          },
+        ],
+      },
+    },
+    {
+      label: 'outdoors',
+      data: {
+        slices: [
+          {
+            value: 5,
+            label: 'dogs',
+          },
+          {
+            value: 33,
+            label: 'cats',
+          },
+        ],
+      },
+    },
+    {
+      label: 'indoors',
+      data: {
+        slices: [
+          {
+            value: 25,
+            label: 'dogs',
+          },
+          {
+            value: 10,
+            label: 'cats',
+          },
+        ],
+      },
+    },
+    {
+      label: 'outdoors',
+      data: {
+        slices: [
+          {
+            value: 5,
+            label: 'dogs',
+          },
+          {
+            value: 33,
+            label: 'cats',
+          },
+        ],
+      },
+    },
+    {
+      label: 'indoors',
+      data: {
+        slices: [
+          {
+            value: 25,
+            label: 'dogs',
+          },
+          {
+            value: 10,
+            label: 'cats',
+          },
+        ],
+      },
+    },
+    {
+      label: 'outdoors',
+      data: {
+        slices: [
+          {
+            value: 5,
+            label: 'dogs',
+          },
+          {
+            value: 33,
+            label: 'cats',
+          },
+        ],
+      },
+    },
+    {
+      label: 'indoors',
+      data: {
+        slices: [
+          {
+            value: 25,
+            label: 'dogs',
+          },
+          {
+            value: 10,
+            label: 'cats',
+          },
+        ],
+      },
+    },
+    {
+      label: 'outdoors',
+      data: {
+        slices: [
+          {
+            value: 5,
+            label: 'dogs',
+          },
+          {
+            value: 33,
+            label: 'cats',
+          },
+        ],
+      },
+    },
+    {
+      label: 'indoors',
+      data: {
+        slices: [
+          {
+            value: 25,
+            label: 'dogs',
+          },
+          {
+            value: 10,
+            label: 'cats',
+          },
+        ],
+      },
+    },
+    {
+      label: 'outdoors',
+      data: {
+        slices: [
+          {
+            value: 5,
+            label: 'dogs',
+          },
+          {
+            value: 33,
+            label: 'cats',
+          },
+        ],
+      },
+    },
+    {
+      label: 'indoors',
+      data: {
+        slices: [
+          {
+            value: 25,
+            label: 'dogs',
+          },
+          {
+            value: 10,
+            label: 'cats',
+          },
+        ],
+      },
+    },
+    {
+      label: 'outdoors',
+      data: {
+        slices: [
+          {
+            value: 5,
+            label: 'dogs',
+          },
+          {
+            value: 33,
+            label: 'cats',
+          },
+        ],
+      },
+    },
   ],
 };
 
@@ -209,5 +389,10 @@ Faceted.args = {
   data: facetedData,
   props: {
     title: 'indoor and outdoor pets',
+    containerStyles: {
+      width: 300,
+      height: 300,
+      border: '1px solid #dadada',
+    },
   },
 };


### PR DESCRIPTION
This PR includes changes to make the faceted plot container element scrollable. The changes are pretty minimal.

Some decisions are needed on how to best apply plot-specific container styles. The most viable short-term approach is to set the container styles in the consuming component (i.e., in web-eda visualizations). Once we have a better handle on what the ideal plot-specific container styles are, we can consider creating plot-specific `FacetedPlot` components in this repo.

ETA I used the CSS grid layout for the container element. This is future-looking for when we enable wrapping and multi facet variables.