### PR TITLE
Introduce refs for FacetedPlot

### DIFF
--- a/src/plots/FacetedPlot.tsx
+++ b/src/plots/FacetedPlot.tsx
@@ -1,20 +1,37 @@
-import React from 'react';
+import React, { Ref, forwardRef, useImperativeHandle, useRef } from 'react';
+
+import { memoize } from 'lodash';
+
 import { isFaceted } from '../types/guards';
 import { FacetedData } from '../types/plots';
-import { PlotProps } from './PlotlyPlot';
+import { ComponentWithPlotRef, PlotProps, PlotRef } from './PlotlyPlot';
 
 export interface FacetedPlotProps<D, P extends PlotProps<D>> {
   data?: FacetedData<D>;
-  component: React.ElementType<P>;
+  component: ComponentWithPlotRef<P>;
   props: P;
 }
 
-export default function FacetedPlot<D, P extends PlotProps<D>>(
-  props: FacetedPlotProps<D, P>
-) {
-  const { data, component, props: componentProps } = props;
+export type FacetedPlotRef = PlotRef[];
 
-  const Component = component as React.ElementType; // casting seems to be needed if using component: React.ElementType<P>; above
+function renderFacetedPlot<D, P extends PlotProps<D>>(
+  props: FacetedPlotProps<D, P>,
+  ref: Ref<FacetedPlotRef>
+) {
+  const { data, component: Component, props: componentProps } = props;
+  const plotRefs = useRef<FacetedPlotRef>([]);
+
+  useImperativeHandle<FacetedPlotRef, FacetedPlotRef>(
+    ref,
+    () => {
+      const plotRefsLength = data?.facets.length ?? 0;
+
+      plotRefs.current = plotRefs.current.slice(0, plotRefsLength);
+
+      return plotRefs.current;
+    },
+    [data?.facets]
+  );
 
   // return a regular plot component if the data isn't faceted.
   if (!isFaceted(data)) {
@@ -27,6 +44,13 @@ export default function FacetedPlot<D, P extends PlotProps<D>>(
           {data?.facets.map(({ data, label }, index) => (
             <Component
               {...componentProps}
+              ref={(plotRef) => {
+                if (plotRef == null) {
+                  delete plotRefs.current[index];
+                } else {
+                  plotRefs.current[index] = plotRef;
+                }
+              }}
               key={index}
               data={data}
               title={label}
@@ -43,4 +67,27 @@ export default function FacetedPlot<D, P extends PlotProps<D>>(
       </div>
     );
   }
+}
+
+const makeFacetedPlotComponent = memoize(function <D, P extends PlotProps<D>>(
+  UnfacetedPlotComponent: ComponentWithPlotRef<P>
+) {
+  const FacetedPlotComponent = forwardRef<
+    FacetedPlotRef,
+    FacetedPlotProps<D, P>
+  >(renderFacetedPlot);
+
+  FacetedPlotComponent.displayName = `FacetedPlotComponent(${
+    UnfacetedPlotComponent.displayName || UnfacetedPlotComponent.name
+  })`;
+
+  return FacetedPlotComponent;
+});
+
+export default function FacetedPlot<D, P extends PlotProps<D>>(
+  props: FacetedPlotProps<D, P> & { facetedPlotRef?: Ref<FacetedPlotRef> }
+) {
+  const FacetedPlotComponent = makeFacetedPlotComponent<D, P>(props.component);
+
+  return <FacetedPlotComponent {...props} ref={props.facetedPlotRef} />;
 }

--- a/src/plots/FacetedPlot.tsx
+++ b/src/plots/FacetedPlot.tsx
@@ -54,11 +54,11 @@ function renderFacetedPlot<D, P extends PlotProps<D>>(
           {data?.facets.map(({ data, label }, index) => (
             <Component
               {...componentProps}
-              ref={(plotRef) => {
-                if (plotRef == null) {
+              ref={(plotInstance) => {
+                if (plotInstance == null) {
                   delete plotRefs.current[index];
                 } else {
-                  plotRefs.current[index] = plotRef;
+                  plotRefs.current[index] = plotInstance;
                 }
               }}
               key={index}

--- a/src/plots/FacetedPlot.tsx
+++ b/src/plots/FacetedPlot.tsx
@@ -1,18 +1,28 @@
-import React, { Ref, forwardRef, useImperativeHandle, useRef } from 'react';
+import React, {
+  ComponentType,
+  PropsWithoutRef,
+  Ref,
+  RefAttributes,
+  forwardRef,
+  useImperativeHandle,
+  useRef,
+} from 'react';
 
 import { memoize } from 'lodash';
 
 import { isFaceted } from '../types/guards';
-import { FacetedData } from '../types/plots';
-import { ComponentWithPlotRef, PlotProps, PlotRef } from './PlotlyPlot';
+import { FacetedData, FacetedPlotRef, PlotRef } from '../types/plots';
+import { PlotProps } from './PlotlyPlot';
+
+type ComponentWithPlotRef<P> = ComponentType<
+  PropsWithoutRef<P> & RefAttributes<PlotRef>
+>;
 
 export interface FacetedPlotProps<D, P extends PlotProps<D>> {
   data?: FacetedData<D>;
   component: ComponentWithPlotRef<P>;
   props: P;
 }
-
-export type FacetedPlotRef = PlotRef[];
 
 function renderFacetedPlot<D, P extends PlotProps<D>>(
   props: FacetedPlotProps<D, P>,

--- a/src/plots/PlotlyPlot.tsx
+++ b/src/plots/PlotlyPlot.tsx
@@ -1,12 +1,15 @@
 import React, {
-  lazy,
-  Suspense,
-  useMemo,
-  useCallback,
+  ComponentType,
   CSSProperties,
+  PropsWithoutRef,
   Ref,
-  useImperativeHandle,
+  RefAttributes,
+  Suspense,
   forwardRef,
+  lazy,
+  useCallback,
+  useImperativeHandle,
+  useMemo,
 } from 'react';
 import { PlotParams } from 'react-plotly.js';
 import { legendSpecification } from '../utils/plotly';
@@ -358,6 +361,10 @@ function PlotlyPlot<T>(
     </Suspense>
   );
 }
+
+export type ComponentWithPlotRef<P> = ComponentType<
+  PropsWithoutRef<P> & RefAttributes<PlotRef>
+>;
 
 const PlotlyPlotWithRef = forwardRef(PlotlyPlot);
 

--- a/src/plots/PlotlyPlot.tsx
+++ b/src/plots/PlotlyPlot.tsx
@@ -1,9 +1,6 @@
 import React, {
-  ComponentType,
   CSSProperties,
-  PropsWithoutRef,
   Ref,
-  RefAttributes,
   Suspense,
   forwardRef,
   lazy,

--- a/src/plots/PlotlyPlot.tsx
+++ b/src/plots/PlotlyPlot.tsx
@@ -14,6 +14,7 @@ import React, {
 import { PlotParams } from 'react-plotly.js';
 import { legendSpecification } from '../utils/plotly';
 import Spinner from '../components/Spinner';
+import { PlotRef } from '../types/plots';
 import {
   PlotLegendAddon,
   PlotSpacingAddon,
@@ -26,15 +27,6 @@ import { select } from 'd3';
 import { ToImgopts, toImage } from 'plotly.js';
 import { uniqueId } from 'lodash';
 import { makeSharedPromise } from '../utils/promise-utils';
-
-/**
- * A generic imperative interface to plota. This allows us to create a facade
- * to interact with plot internals, such as exporting an image.
- */
-
-export interface PlotRef {
-  toImage: (imageOpts: ToImgopts) => Promise<string>;
-}
 
 export interface PlotProps<T> extends ColorPaletteAddon {
   /** plot data - following web-components' API, not Plotly's */
@@ -361,10 +353,6 @@ function PlotlyPlot<T>(
     </Suspense>
   );
 }
-
-export type ComponentWithPlotRef<P> = ComponentType<
-  PropsWithoutRef<P> & RefAttributes<PlotRef>
->;
 
 const PlotlyPlotWithRef = forwardRef(PlotlyPlot);
 

--- a/src/stories/plots/PlotlyPlot.stories.tsx
+++ b/src/stories/plots/PlotlyPlot.stories.tsx
@@ -1,7 +1,8 @@
 import { useEffect } from 'react';
 import { useState } from 'react';
 import { useRef } from 'react';
-import PlotlyPlot, { PlotRef } from '../../plots/PlotlyPlot';
+import PlotlyPlot from '../../plots/PlotlyPlot';
+import { PlotRef } from '../../types/plots';
 
 export default {
   title: 'Plots/PlotlyPlot',

--- a/src/types/guards.ts
+++ b/src/types/guards.ts
@@ -11,8 +11,10 @@ import {
 } from './general';
 import {
   FacetedData,
+  FacetedPlotRef,
   HistogramData,
   PiePlotData,
+  PlotRef,
   UnionOfPlotDataTypes,
 } from './plots';
 import { LinePlotData } from './plots/linePlot';
@@ -94,4 +96,11 @@ export function isFaceted<T>(
     'every' in maybeFacetedData.facets &&
     maybeFacetedData.facets.every((d) => 'label' in d && 'data' in d)
   );
+}
+
+/** Is this plot ref a FacetedPlotRef? */
+export function isFacetedPlotRef(
+  maybeFacetedPlotRef?: FacetedPlotRef | PlotRef
+): maybeFacetedPlotRef is FacetedPlotRef {
+  return Array.isArray(maybeFacetedPlotRef);
 }

--- a/src/types/plots/index.ts
+++ b/src/types/plots/index.ts
@@ -1,6 +1,8 @@
 /**
  * Module used as a convenience wrapper for related type definitions.
  */
+import { ToImgopts } from 'plotly.js';
+
 import { HistogramData } from './histogram';
 import { LinePlotData } from './linePlot';
 import { PiePlotData } from './piePlot';
@@ -10,6 +12,16 @@ import { BarplotData } from './barplot';
 import { HeatmapData } from './heatmap';
 import { MosaicData } from './mosaic';
 import { BirdsEyePlotData } from './birdseyeplot';
+
+/**
+ * A generic imperative interface to plota. This allows us to create a facade
+ * to interact with plot internals, such as exporting an image.
+ */
+export interface PlotRef {
+  toImage: (imageOpts: ToImgopts) => Promise<string>;
+}
+
+export type FacetedPlotRef = PlotRef[];
 
 export type FacetedData<D> = {
   facets: {


### PR DESCRIPTION
(Relates to https://github.com/VEuPathDB/web-components/issues/241.)

This PR introduces refs for `FacetedPlot`s.

A `FacetedPlot` ref is defined to be an _array_ of the `PlotRef`s for each rendered subplot; in particular, a `FacetedPlot` instance exposes each subplot's `toImage` callback, so that we can create assemble thumbnails from multiple subplots.

**Future work:**

@dmfalke recently suggested that we make plot-specific `FacetedPlot` components (e.g., `FacetedHistogram`) and apply plot-specific styles there; when it comes time to do that work, the `makeFacetedPlotComponent` factory which I introduced here might help.