### PR TITLE
Use vertical ticks for mosaic plot

### DIFF
--- a/src/plots/MosaicPlot.tsx
+++ b/src/plots/MosaicPlot.tsx
@@ -11,6 +11,7 @@ import _ from 'lodash';
 // util functions for handling long tick labels with ellipsis
 import { axisTickLableEllipsis } from '../utils/axis-tick-label-ellipsis';
 import { makeStyles } from '@material-ui/core/styles';
+import { Layout } from 'plotly.js';
 
 export interface MosaicPlotProps extends PlotProps<MosaicData> {
   /** label for independent axis */
@@ -154,10 +155,11 @@ const MosaicPlot = makePlotlyPlotComponent(
       marginLeft: marginLeft + marginLeftExtra,
     };
 
-    const layout = {
+    const layout: Partial<Layout> = {
       xaxis: {
         title: independentAxisLabel,
         tickvals: column_centers,
+        tickangle: 90,
         ticktext:
           showColumnLabels !== false
             ? // use ellipsis texts here
@@ -187,7 +189,7 @@ const MosaicPlot = makePlotlyPlotComponent(
         itemdoubleclick: false,
       },
       hovermode: 'x',
-    } as const;
+    } as Partial<Layout>;
 
     const plotlyReadyData: PlotParams['data'] = data.values
       .map(


### PR DESCRIPTION
When x-axis ticks are displayed diagonally, it can cause the width of the plot to vary, since plotly factors the amount of space needed by ticks as a part of the total plot dimensions.

**Before**
![image](https://user-images.githubusercontent.com/365139/141892342-5b5e535f-8e73-41b1-ad07-9a0f715e5c95.png)

**After**
![image](https://user-images.githubusercontent.com/365139/141892394-38e1acab-2092-4334-bc48-fca6417ed348.png)

closes #257 