### PR TITLE
Empty facet data as undefined - DRAFT for illustration purposes only.

### DIFF
--- a/src/plots/FacetedPlot.tsx
+++ b/src/plots/FacetedPlot.tsx
@@ -72,7 +72,7 @@ function renderFacetedPlot<D, P extends PlotProps<D>>(
             }}
             key={index}
             data={data}
-            title={label}
+            title={data == null ? `NO DATA: ${label}` : label}
             displayLegend={false}
             interactive={false}
             // pass checkedLegendItems to PlotlyPlot

--- a/src/types/plots/index.ts
+++ b/src/types/plots/index.ts
@@ -26,7 +26,7 @@ export type FacetedPlotRef = PlotRef[];
 export type FacetedData<D> = {
   facets: {
     label: string;
-    data: D;
+    data?: D;
   }[];
 };
 


### PR DESCRIPTION
This PR very trivially allows `facet.data = undefined` and when a facet has undefined data, the title is temporarily rendered with a "NO DATA" prefix.

This allows [this EDA ticket](https://github.com/VEuPathDB/web-eda/pull/721) to handle empty facets consistently and reasonably elegantly. 