### PR TITLE
Mosaic - blank out x axis labels when they have all zero values

### DIFF
--- a/src/plots/MosaicPlot.tsx
+++ b/src/plots/MosaicPlot.tsx
@@ -68,7 +68,12 @@ const MosaicPlot = makePlotlyPlotComponent(
         axisTickLableEllipsis(
           data.independentLabels,
           maxIndependentTickLabelLength
-        ),
+        )
+          // now replace labels for any all-zero 'series' with a white space
+          // (tried an empty string but it causes major weirdness)
+          .map((label, index) =>
+            _.unzip(data.values)[index].every((v) => v === 0) ? ' ' : label
+          ),
       [data]
     );
 


### PR DESCRIPTION
This is to go with an EDA ticket to be mentioned soon.

See screenshots at https://github.com/VEuPathDB/web-eda/issues/715 for more info.
