### PR TITLE
Disable hover in Birds Eye Plot in favour of EDA-side mouse-over

### DIFF
--- a/src/plots/BirdsEyePlot.tsx
+++ b/src/plots/BirdsEyePlot.tsx
@@ -161,7 +161,7 @@ export default function BirdsEyePlot({
     },
     barmode: 'overlay',
     shapes: plotlyShapes,
-    hovermode: 'y unified',
+    hovermode: false,
     hoverdistance: 1000,
     hoverlabel: {
       namelength: -1, // this should disable ellipsis truncation, but it still does... :(


### PR DESCRIPTION
Fixes https://github.com/VEuPathDB/web-components/issues/263
Something broke in the Plotly upgrade and it seems impossible to fix here.

So disabling it completely and going with an EDA-side solution.