### PR TITLE
ContingencyTable: introduce singleFacetContainerStyles and facetedContainerStyles props

### DIFF
--- a/src/components/ContingencyTable.tsx
+++ b/src/components/ContingencyTable.tsx
@@ -10,9 +10,12 @@ interface ContingencyTableProps {
   independentVariable: string;
   dependentVariable: string;
   facetVariable?: string;
-  containerStyles?: CSSProperties;
-  facetedContainerStyles?: CSSProperties;
+  /** Styling for the component's data table(s) */
+  tableContainerStyles?: CSSProperties;
+  /** Styling for the title + data table for a single facet */
   singleFacetContainerStyles?: CSSProperties;
+  /** Styling for the container of all facets */
+  facetedContainerStyles?: CSSProperties;
   enableSpinner?: boolean;
 }
 
@@ -69,7 +72,7 @@ export function ContingencyTable(props: ContingencyTableProps) {
   const rowSums = data.values.map((row) => _.sum(row));
 
   return (
-    <div className="contingency-table" style={props.containerStyles}>
+    <div className="contingency-table" style={props.tableContainerStyles}>
       <table>
         <tbody>
           <tr>

--- a/src/components/ContingencyTable.tsx
+++ b/src/components/ContingencyTable.tsx
@@ -11,31 +11,34 @@ interface ContingencyTableProps {
   dependentVariable: string;
   facetVariable?: string;
   containerStyles?: CSSProperties;
+  facetedContainerStyles?: CSSProperties;
+  singleFacetContainerStyles?: CSSProperties;
   enableSpinner?: boolean;
 }
 
 function FacetedContingencyTable(props: ContingencyTableProps) {
   if (isFaceted(props.data) && props.facetVariable != null) {
     return (
-      <div className="faceted-contingency-table" style={props.containerStyles}>
-        <table>
-          <tbody>
-            {props.data.facets.map(({ label, data }) => (
-              <>
-                <tr>
-                  <th style={{ border: 'none' /* cancel WDK style! */ }}>
-                    {props.facetVariable}: {label}
-                  </th>
-                </tr>
-                <tr>
-                  <td>
-                    <ContingencyTable {...props} data={data} />
-                  </td>
-                </tr>
-              </>
-            ))}
-          </tbody>
-        </table>
+      <div
+        className="faceted-contingency-table"
+        style={props.facetedContainerStyles}
+      >
+        {props.data.facets.map(({ label, data }, index) => (
+          <table key={index} style={props.singleFacetContainerStyles}>
+            <tbody>
+              <tr>
+                <th style={{ border: 'none' /* cancel WDK style! */ }}>
+                  {props.facetVariable}: {label}
+                </th>
+              </tr>
+              <tr>
+                <td>
+                  <ContingencyTable {...props} data={data} />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        ))}
       </div>
     );
   } else {

--- a/src/components/ContingencyTable.tsx
+++ b/src/components/ContingencyTable.tsx
@@ -10,9 +10,13 @@ interface ContingencyTableProps {
   independentVariable: string;
   dependentVariable: string;
   facetVariable?: string;
-  /** Styling for the component's data table(s) */
+  /**
+   *  Styling for the component's data table(s).
+   *  Also doubles as the container styling when
+   *  the component is rendering unfaceted data.
+   */
   tableContainerStyles?: CSSProperties;
-  /** Styling for the title + data table for a single facet */
+  /** Styling for a single facet (title + data table) */
   singleFacetContainerStyles?: CSSProperties;
   /** Styling for the container of all facets */
   facetedContainerStyles?: CSSProperties;


### PR DESCRIPTION
This PR introduces new `FacetedContingencyTable` styling props for:

1. The container housing the title and contingency table for a single facet (`singleFacetContainerStyles`)
2. The container for the entire "collection" of facets (`facetedContainerStyles`)

For added clarity, `containerStyles` is also renamed to `tableContainerStyles`.

(In particular, we can use `tableContainerStyles` to specify how the data table(s) should be styled, `singleFacetContainerStyles` to specify the layout for a single facet (title + data table), and `facetedContainerStyles` to specify the layout for all the facets.)
