### PR TITLE
add R-square prop to Scatter plot

### DIFF
--- a/src/types/plots/xyplot.ts
+++ b/src/types/plots/xyplot.ts
@@ -33,6 +33,8 @@ export type XYPlotDataSeries = {
   fill?: 'tozerox' | 'tozeroy' | 'toself';
   /** filling plots: color */
   fillcolor?: string;
+  /** R-square value for Best fit option */
+  r2?: number;
 };
 
 export type XYPlotData = {


### PR DESCRIPTION
While making a R-square table for Scatter plot with the plot options of Best fit with raw ([#694 at web-eda](https://github.com/VEuPathDB/web-eda/issues/694)), it was necessary to add a prop to have R-square value.