### PR TITLE
several custom legend works

### DIFF
--- a/src/components/plotControls/PlotLegend.tsx
+++ b/src/components/plotControls/PlotLegend.tsx
@@ -55,9 +55,15 @@ export default function PlotLegend({
       {legendItems.length > 1 && (
         <div
           style={{
+            display: 'inline-block', // for general usage (e.g., story)
             border: '1px solid #dedede',
             boxShadow: '1px 1px 4px #00000066',
             padding: '1em',
+            // implementing scrolling for vertical direction
+            maxHeight: 250, // same height with Scatterplot R-square table
+            minWidth: 250, // for firefox
+            overflowX: 'hidden',
+            overflowY: 'auto',
           }}
         >
           <div
@@ -70,20 +76,38 @@ export default function PlotLegend({
           </div>
           <div className="plotLegendCheckbox">
             {legendItems.map((item: LegendItemsProps, index: number) => (
-              <div key={item.label} style={{ display: 'flex' }}>
-                <>
+              <div key={item.label}>
+                {/* wrap checkbox with label so that label text is clickable */}
+                <label
+                  key={item.label}
+                  title={item.label}
+                  style={{
+                    cursor: 'pointer',
+                    display: 'flex',
+                    alignItems: 'center',
+                    fontSize: legendTextSize,
+                    // gray out for filtered item
+                    color:
+                      checkedLegendItems?.includes(item.label) && item.hasData
+                        ? ''
+                        : '#999',
+                    // add this for general usage (e.g., story)
+                    margin: 0,
+                  }}
+                >
                   <Checkbox
                     key={item.label}
                     id={item.label}
                     value={item.label}
-                    color="primary"
+                    // gray checkbox: default
+                    color={'default'}
                     onChange={(e) => {
                       handleLegendCheckboxClick(e.target.checked, item.label);
                     }}
                     checked={
                       checkedLegendItems?.includes(item.label) ? true : false
                     }
-                    style={{ padding: 0 }}
+                    style={{ padding: 0, width: '1em', height: '1em' }}
                     // disable when hasData is false
                     // but scatter plot needs further change due to smoothed mean and best fit
                     disabled={!item.hasData}
@@ -91,8 +115,8 @@ export default function PlotLegend({
                   &nbsp;&nbsp;
                   <div
                     style={{
-                      position: 'relative',
-                      margin: 'auto 0',
+                      display: 'flex',
+                      alignItems: 'center',
                     }}
                   >
                     {/* for histogram, barplot, Mosaic (2X2, RXC) - Mosaic does not use custom legend though */}
@@ -161,8 +185,6 @@ export default function PlotLegend({
                             height: '0.15em',
                             width: scatterMarkerSpace,
                             borderWidth: '0',
-                            // borderStyle: 'solid',
-                            // borderRadius: '0.6em',
                             backgroundColor:
                               checkedLegendItems?.includes(item.label) &&
                               item.hasData
@@ -211,29 +233,18 @@ export default function PlotLegend({
                       </div>
                     )}
                   </div>
+                  {/* below is label text */}
                   &nbsp;&nbsp;
-                  <label
-                    title={item.label}
-                    style={{
-                      cursor: 'pointer',
-                      display: 'flex',
-                      alignItems: 'center',
-                      fontSize: legendTextSize,
-                      // gray out for filtered item
-                      color:
-                        checkedLegendItems?.includes(item.label) && item.hasData
-                          ? ''
-                          : '#999',
-                    }}
-                  >
+                  <div>
                     {item.label === 'No data' ||
                     item.label.includes('No data,') ? (
                       <i>{legendEllipsis(item.label, 20)}</i>
                     ) : (
                       legendEllipsis(item.label, 20)
                     )}
-                  </label>
-                </>
+                  </div>
+                  {/* </div> */}
+                </label>
               </div>
             ))}
           </div>

--- a/src/stories/plotControls/PlotLegend.stories.tsx
+++ b/src/stories/plotControls/PlotLegend.stories.tsx
@@ -215,6 +215,178 @@ const legendItems = [
   },
 ];
 
+// test data for long legend items: taken from Scatterplot with Smoothed mean
+const longLegendItems = [
+  {
+    label: 'Bangladesh',
+    marker: 'circle',
+    markerColor: 'rgb(136,34,85)',
+    hasData: true,
+    group: 1,
+    rank: 1,
+  },
+  {
+    label: 'India',
+    marker: 'circle',
+    markerColor: 'rgb(136,204,238)',
+    hasData: true,
+    group: 1,
+    rank: 1,
+  },
+  {
+    label: 'Kenya',
+    marker: 'circle',
+    markerColor: 'rgb(153,153,51)',
+    hasData: true,
+    group: 1,
+    rank: 1,
+  },
+  {
+    label: 'Mali',
+    marker: 'circle',
+    markerColor: 'rgb(51,34,136)',
+    hasData: true,
+    group: 1,
+    rank: 1,
+  },
+  {
+    label: 'Mozambique',
+    marker: 'circle',
+    markerColor: 'rgb(68,170,153)',
+    hasData: true,
+    group: 1,
+    rank: 1,
+  },
+  {
+    label: 'Pakistan',
+    marker: 'circle',
+    markerColor: 'rgb(221,204,119)',
+    hasData: true,
+    group: 1,
+    rank: 1,
+  },
+  {
+    label: 'The Gambia',
+    marker: 'circle',
+    markerColor: 'rgb(204,102,119)',
+    hasData: true,
+    group: 1,
+    rank: 1,
+  },
+  {
+    label: 'Bangladesh, Smoothed mean',
+    marker: 'line',
+    markerColor: 'rgb(136,34,85)',
+    hasData: true,
+    group: 1,
+    rank: 1,
+  },
+  {
+    label: 'Bangladesh, 95% Confidence interval',
+    marker: 'fainted',
+    markerColor: 'rgb(136,34,85)',
+    hasData: true,
+    group: 1,
+    rank: 1,
+  },
+  {
+    label: 'India, Smoothed mean',
+    marker: 'line',
+    markerColor: 'rgb(136,204,238)',
+    hasData: false,
+    group: 1,
+    rank: 1,
+  },
+  {
+    label: 'India, 95% Confidence interval',
+    marker: 'fainted',
+    markerColor: 'rgb(136,204,238)',
+    hasData: false,
+    group: 1,
+    rank: 1,
+  },
+  {
+    label: 'Kenya, Smoothed mean',
+    marker: 'line',
+    markerColor: 'rgb(153,153,51)',
+    hasData: false,
+    group: 1,
+    rank: 1,
+  },
+  {
+    label: 'Kenya, 95% Confidence interval',
+    marker: 'fainted',
+    markerColor: 'rgb(153,153,51)',
+    hasData: false,
+    group: 1,
+    rank: 1,
+  },
+  {
+    label: 'Mali, Smoothed mean',
+    marker: 'line',
+    markerColor: 'rgb(51,34,136)',
+    hasData: true,
+    group: 1,
+    rank: 1,
+  },
+  {
+    label: 'Mali, 95% Confidence interval',
+    marker: 'fainted',
+    markerColor: 'rgb(51,34,136)',
+    hasData: true,
+    group: 1,
+    rank: 1,
+  },
+  {
+    label: 'Mozambique, Smoothed mean',
+    marker: 'line',
+    markerColor: 'rgb(68,170,153)',
+    hasData: true,
+    group: 1,
+    rank: 1,
+  },
+  {
+    label: 'Mozambique, 95% Confidence interval',
+    marker: 'fainted',
+    markerColor: 'rgb(68,170,153)',
+    hasData: true,
+    group: 1,
+    rank: 1,
+  },
+  {
+    label: 'Pakistan, Smoothed mean',
+    marker: 'line',
+    markerColor: 'rgb(221,204,119)',
+    hasData: true,
+    group: 1,
+    rank: 1,
+  },
+  {
+    label: 'Pakistan, 95% Confidence interval',
+    marker: 'fainted',
+    markerColor: 'rgb(221,204,119)',
+    hasData: true,
+    group: 1,
+    rank: 1,
+  },
+  {
+    label: 'The Gambia, Smoothed mean',
+    marker: 'line',
+    markerColor: 'rgb(204,102,119)',
+    hasData: true,
+    group: 1,
+    rank: 1,
+  },
+  {
+    label: 'The Gambia, 95% Confidence interval',
+    marker: 'fainted',
+    markerColor: 'rgb(204,102,119)',
+    hasData: true,
+    group: 1,
+    rank: 1,
+  },
+];
+
 // set some default props
 const plotWidth = 1000;
 const plotHeight = 600;
@@ -257,6 +429,28 @@ export const HistogramPlotLegend = () => {
         onCheckedLegendItemsChange={setCheckedLegendItems}
         // pass legend title
         legendTitle={'Age group'}
+      />
+    </div>
+  );
+};
+
+// custom legend with histogram
+export const TestLongLegendItems = () => {
+  // long legend test
+  const [checkedLongLegendItems, setCheckedLongLegendItems] = useState<
+    string[]
+  >(longLegendItems.map((item) => item.label));
+
+  return (
+    <div>
+      {/* testing long legend items: taken from a Scatter plot with smoothed mean */}
+      <h5># Testing long legend items</h5>
+      <PlotLegend
+        legendItems={longLegendItems}
+        checkedLegendItems={checkedLongLegendItems}
+        onCheckedLegendItemsChange={setCheckedLongLegendItems}
+        // pass legend title
+        legendTitle={'Country'}
       />
     </div>
   );


### PR DESCRIPTION
This PR will address the following works:
a) changing checkbox color into grayish - discussed at [#765](https://github.com/VEuPathDB/web-eda/issues/765)
b) making legend label clickable to select/unselect checkbox #271 
c) considering scrollbar when the number of legend list is large: currently set to the height of Scatter plot's R-square table (story is added)
d) several changes for better display

Here is an example screenshot of a faceted plot with R-square table:

![scatter-legend-scrollbar](https://user-images.githubusercontent.com/12802305/146196545-7e9af007-dbd1-4b43-b974-a4da5397254f.png)

