### PR TITLE
Pass all componentProps to faceted modal

### DIFF
--- a/src/plots/FacetedPlot.tsx
+++ b/src/plots/FacetedPlot.tsx
@@ -78,6 +78,7 @@ function renderFacetedPlot<D, P extends PlotProps<D>>(
         {data?.facets.map(({ data, label }, index) => {
           const sharedProps = {
             data: data,
+            ...componentProps,
             // pass checkedLegendItems to PlotlyPlot
             checkedLegendItems: checkedLegendItems,
             showNoDataOverlay: data == null,
@@ -120,7 +121,6 @@ function renderFacetedPlot<D, P extends PlotProps<D>>(
                 }}
                 displayLegend={false}
                 interactive={false}
-                {...componentProps}
                 title={label}
               />
             </div>


### PR DESCRIPTION
The histogram modals were reverting to `barLayout: undefined` and so were reverting to overlay mode (they should be 'stacked').  This made me realise that other props weren't being passed to the modal, such as log scale.  This fixes that.  Small fix on the EDA-side to remove some redundancy and upgrade to this version when merged.

Not putting this (and EDA sibling) ticket in the project board ticket cycle.

Small facet plot:
![image](https://user-images.githubusercontent.com/308639/146206615-84fcd8bf-bce6-40ab-90e0-0e9f07ec18d1.png)
Modal:
![image](https://user-images.githubusercontent.com/308639/146206567-8546a1ec-6f4d-4420-ac3b-22a98b089074.png)
