### PR TITLE
Right align table numbers

### DIFF
--- a/src/components/ContingencyTable.tsx
+++ b/src/components/ContingencyTable.tsx
@@ -74,6 +74,8 @@ export function ContingencyTable(props: ContingencyTableProps) {
   }
 
   const rowSums = data.values.map((row) => _.sum(row));
+  const numericHeaderStyles = { textAlign: 'center' } as const;
+  const numericValueStyles = { textAlign: 'right' } as const;
 
   return (
     <div className="contingency-table" style={props.tableContainerStyles}>
@@ -100,14 +102,14 @@ export function ContingencyTable(props: ContingencyTableProps) {
               <th
                 key={label}
                 className="contingency-table_column-label"
-                style={{ textAlign: 'right' }}
+                style={numericHeaderStyles}
               >
                 {label}
               </th>
             ))}
             <th
               className="contingency-table_totals-column-header"
-              style={{ textAlign: 'right' }}
+              style={numericHeaderStyles}
             >
               Total
             </th>
@@ -121,14 +123,14 @@ export function ContingencyTable(props: ContingencyTableProps) {
                 <td
                   key={`${data.dependentLabels[i]}-${data.independentLabels[j]}`}
                   className="contingency-table_value"
-                  style={{ textAlign: 'right' }}
+                  style={numericValueStyles}
                 >
                   {value.toLocaleString()}
                 </td>
               ))}
               <td
                 className="contingency-table_totals-column-value"
-                style={{ textAlign: 'right' }}
+                style={numericValueStyles}
               >
                 {rowSums[i].toLocaleString()}
               </td>
@@ -140,14 +142,14 @@ export function ContingencyTable(props: ContingencyTableProps) {
               <td
                 key={data.independentLabels[i]}
                 className="contingency-table_totals-row-value"
-                style={{ textAlign: 'right' }}
+                style={numericValueStyles}
               >
                 {_.sum(col).toLocaleString()}
               </td>
             ))}
             <td
               className="contingency-table_grand-total"
-              style={{ textAlign: 'right' }}
+              style={numericValueStyles}
             >
               {_.sum(rowSums).toLocaleString()}
             </td>

--- a/src/components/ContingencyTable.tsx
+++ b/src/components/ContingencyTable.tsx
@@ -97,11 +97,20 @@ export function ContingencyTable(props: ContingencyTableProps) {
               {props.dependentVariable}
             </th>
             {data.independentLabels.map((label) => (
-              <th key={label} className="contingency-table_column-label">
+              <th
+                key={label}
+                className="contingency-table_column-label"
+                style={{ textAlign: 'right' }}
+              >
                 {label}
               </th>
             ))}
-            <th className="contingency-table_totals-column-header">Total</th>
+            <th
+              className="contingency-table_totals-column-header"
+              style={{ textAlign: 'right' }}
+            >
+              Total
+            </th>
           </tr>
           {data.values.map((row, i) => (
             <tr key={data.dependentLabels[i]}>
@@ -112,11 +121,15 @@ export function ContingencyTable(props: ContingencyTableProps) {
                 <td
                   key={`${data.dependentLabels[i]}-${data.independentLabels[j]}`}
                   className="contingency-table_value"
+                  style={{ textAlign: 'right' }}
                 >
                   {value.toLocaleString()}
                 </td>
               ))}
-              <td className="contingency-table_totals-column-value">
+              <td
+                className="contingency-table_totals-column-value"
+                style={{ textAlign: 'right' }}
+              >
                 {rowSums[i].toLocaleString()}
               </td>
             </tr>
@@ -127,11 +140,15 @@ export function ContingencyTable(props: ContingencyTableProps) {
               <td
                 key={data.independentLabels[i]}
                 className="contingency-table_totals-row-value"
+                style={{ textAlign: 'right' }}
               >
                 {_.sum(col).toLocaleString()}
               </td>
             ))}
-            <td className="contingency-table_grand-total">
+            <td
+              className="contingency-table_grand-total"
+              style={{ textAlign: 'right' }}
+            >
               {_.sum(rowSums).toLocaleString()}
             </td>
           </tr>


### PR DESCRIPTION
Works toward https://github.com/VEuPathDB/web-eda/issues/761

![image](https://user-images.githubusercontent.com/12377649/146425824-eaa1497a-d621-4199-aad7-d095cc11c26c.png)

I also right-aligned the column labels that sit above right-aligned numbers. The variable coverage table will be handled in web-eda.

Interestingly, I believe the numbers in this font are equal-width, even though the font's letters are not. I didn't realize some fonts did that. Neat!