### PR TITLE
Remove boxplot empty gap

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/components",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "license": "Apache-2.0",
   "description": "React Components for VEuPathDB Websites",
   "repository": {

--- a/src/plots/Boxplot.tsx
+++ b/src/plots/Boxplot.tsx
@@ -135,9 +135,6 @@ const Boxplot = makePlotlyPlotComponent('Boxplot', (props: BoxplotProps) => {
               fillcolor: d.color,
               ...orientationDependentProps,
               type: 'box',
-              // `offsetgroup` somehow ensures that an overlay value with no data at all will
-              // still be shown as a gap in the boxplots shown above a single x tick.
-              offsetgroup: d.name,
             };
           }) // part 2 of the hack:
           // the following is required because Plotly's 'categoryorder/categoryarray' props do not

--- a/src/plots/Boxplot.tsx
+++ b/src/plots/Boxplot.tsx
@@ -135,6 +135,9 @@ const Boxplot = makePlotlyPlotComponent('Boxplot', (props: BoxplotProps) => {
               fillcolor: d.color,
               ...orientationDependentProps,
               type: 'box',
+              // `offsetgroup` somehow ensures that an overlay value with no data at all will
+              // still be shown as a gap in the boxplots shown above a single x tick.
+              // offsetgroup: d.name,
             };
           }) // part 2 of the hack:
           // the following is required because Plotly's 'categoryorder/categoryarray' props do not


### PR DESCRIPTION
Works toward https://github.com/VEuPathDB/web-components/issues/264

Thankfully the option I needed to change was commented describing this exact behavior :)

Note that the empty space leftover will disappear even if there is just empty data for the series in question, rather than the series being set to invisible, but that the series' legend entry will remain (this appears to be different than in barplot, where the series legend entry disappears for empty data).