### PR TITLE
add a prop to allow displaying legend

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/components",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "license": "Apache-2.0",
   "description": "React Components for VEuPathDB Websites",
   "repository": {

--- a/src/components/plotControls/PlotLegend.tsx
+++ b/src/components/plotControls/PlotLegend.tsx
@@ -19,6 +19,8 @@ interface PlotLegendProps {
   legendTitle?: string;
   // use onCheckedLegendItemsChange
   onCheckedLegendItemsChange?: (checkedLegendItems: string[]) => void;
+  // add a condition to show legend for single overlay data
+  showOverlayLegend?: boolean;
 }
 export default function PlotLegend({
   legendItems,
@@ -26,6 +28,7 @@ export default function PlotLegend({
   legendTitle,
   // use onCheckedLegendItemsChange
   onCheckedLegendItemsChange,
+  showOverlayLegend = false,
 }: PlotLegendProps) {
   // change checkbox state by click
   const handleLegendCheckboxClick = (checked: boolean, id: string) => {
@@ -52,7 +55,8 @@ export default function PlotLegend({
 
   return (
     <>
-      {legendItems.length > 1 && (
+      {/* add a condition to show legend for single overlay data */}
+      {(legendItems.length > 1 || showOverlayLegend) && (
         <div
           style={{
             display: 'inline-block', // for general usage (e.g., story)
@@ -238,7 +242,6 @@ export default function PlotLegend({
                       legendEllipsis(item.label, 20)
                     )}
                   </div>
-                  {/* </div> */}
                 </label>
               </div>
             ))}


### PR DESCRIPTION
This resolves https://github.com/VEuPathDB/EdaNewIssues/issues/202, which allow the case of single overlay data for displaying legend: previously single data is not allowed to show legend.

After sleeping on it, I thought that the simplest case is to add a prop to allow displaying legend, in conjunction with the pre-existing condition to check the data.length > 1 (this is for the case without overlay).

By doing this, a condition to check the presence of vizConfig.overlayVariable will allow to show legend for overlayVariable regardless of its length - will make a PR regarding this at web-eda soon

Here is a screenshot, with the same example used in the issue.
![wash bangladesh overlay single data](https://user-images.githubusercontent.com/12802305/159722007-878e4b19-7481-461e-b13c-6fcb8e18a59c.png)

