### PR TITLE
Update entity diagram UI to represent 1:1 and 1:many relationships

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/components",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "license": "Apache-2.0",
   "description": "React Components for VEuPathDB Websites",
   "repository": {

--- a/src/EntityDiagram/EntityDiagram.stories.tsx
+++ b/src/EntityDiagram/EntityDiagram.stories.tsx
@@ -18,10 +18,11 @@ const rootEntity: StudyData = {
   description: 'Households from the study area',
   children: [
     {
-      id: 'EUPATH_0000776',
+      id: 'GEMS_HouseObs',
       displayName: 'Household Observation',
       description: '',
       children: [],
+      isManyToOneWithParent: true,
       variables: [
         {
           id: 'var-19',

--- a/src/EntityDiagram/EntityDiagram.stories.tsx
+++ b/src/EntityDiagram/EntityDiagram.stories.tsx
@@ -18,7 +18,7 @@ const rootEntity: StudyData = {
   description: 'Households from the study area',
   children: [
     {
-      id: 'GEMS_HouseObs',
+      id: 'EUPATH_0000776',
       displayName: 'Household Observation',
       description: '',
       children: [],
@@ -164,7 +164,7 @@ const entityCounts: EntityCounts = {
     total: 100,
     filtered: 5,
   },
-  GEMS_HouseObs: {
+  EUPATH_0000776: {
     total: 100,
     filtered: 2,
   },

--- a/src/EntityDiagram/EntityDiagram.stories.tsx
+++ b/src/EntityDiagram/EntityDiagram.stories.tsx
@@ -165,7 +165,7 @@ const entityCounts: EntityCounts = {
     total: 100,
     filtered: 5,
   },
-  EUPATH_0000776: {
+  GEMS_HouseObs: {
     total: 100,
     filtered: 2,
   },

--- a/src/EntityDiagram/EntityDiagram.tsx
+++ b/src/EntityDiagram/EntityDiagram.tsx
@@ -336,16 +336,18 @@ export default function EntityDiagram({
     if (isOneToMany) {
       oneToManyNodeEndpoints.push(
         {
-          x: to.x + offset,
-          y: to.y + nodeHeight / 4,
+          x: to.x + (orientation == 'horizontal' ? offset : nodeHeight / 2),
+          y: to.y + (orientation == 'horizontal' ? nodeHeight / 4 : 0),
         },
         {
-          x: to.x + offset,
+          x: to.x + (orientation == 'horizontal' ? offset : 0),
           y: to.y,
         },
         {
-          x: to.x + offset,
-          y: to.y - nodeHeight / 4,
+          x:
+            to.x +
+            (orientation == 'horizontal' ? offset : (nodeHeight / 2) * -1),
+          y: to.y - (orientation == 'horizontal' ? nodeHeight / 4 : 0),
         }
       );
     }
@@ -357,12 +359,19 @@ export default function EntityDiagram({
           to={to}
           stroke="#777"
           strokeWidth={3}
+          // markerStart fills in the void caused by two lines starting from same position
+          markerStart={
+            link.source.children && link.source.children.length > 1
+              ? 'url(#dot-start'
+              : ''
+          }
           markerEnd={isOneToMany ? '' : 'url(#dot)'}
         />
         {isOneToMany
-          ? oneToManyNodeEndpoints.map((endpoint) => {
+          ? oneToManyNodeEndpoints.map((endpoint, index) => {
               return (
                 <Line
+                  key={index}
                   from={to}
                   to={endpoint}
                   stroke="#777"
@@ -376,6 +385,9 @@ export default function EntityDiagram({
     );
   }
 
+  // Can be used to adjust node size if/when this feature is implemented
+  const nodeSize = isExpanded ? 3.5 : 3.5;
+  const markerStartSize = 2;
   return (
     <div className={isExpanded ? 'expanded-diagram' : 'mini-diagram'}>
       <svg width={size.width} height={size.height}>
@@ -383,16 +395,30 @@ export default function EntityDiagram({
           <marker
             id="dot"
             viewBox="0 0 10 10"
-            // markerWidth={isExpanded ? '6' : '3'}
-            // markerHeight={isExpanded ? '4' : '3'}
-            markerWidth={'3.5'}
-            markerHeight={'3.5'}
+            markerWidth={nodeSize}
+            markerHeight={nodeSize}
             orient="auto"
             fill="#777"
-            refX={3.5}
-            refY={3.5}
+            refX={nodeSize}
+            refY={nodeSize}
           >
-            <circle cx="3.5" cy="3.5" r="3.5" />
+            <circle cx={nodeSize} cy={nodeSize} r={nodeSize} />
+          </marker>
+          <marker
+            id="dot-start"
+            viewBox="0 0 10 10"
+            markerWidth={markerStartSize}
+            markerHeight={markerStartSize}
+            orient="auto"
+            fill="#777"
+            refX={markerStartSize + 0.5}
+            refY={markerStartSize}
+          >
+            <circle
+              cx={markerStartSize}
+              cy={markerStartSize}
+              r={markerStartSize}
+            />
           </marker>
           <filter id="shadow" x="-20%" y="-40%" width="150%" height="200%">
             <feDropShadow

--- a/src/EntityDiagram/EntityDiagram.tsx
+++ b/src/EntityDiagram/EntityDiagram.tsx
@@ -359,12 +359,7 @@ export default function EntityDiagram({
           to={to}
           stroke="#777"
           strokeWidth={3}
-          // markerStart fills in the void caused by two lines starting from same position
-          markerStart={
-            link.source.children && link.source.children.length > 1
-              ? 'url(#dot-start'
-              : ''
-          }
+          markerStart={'url(#dot)'}
           markerEnd={isOneToMany ? '' : 'url(#dot)'}
         />
         {isOneToMany
@@ -387,7 +382,6 @@ export default function EntityDiagram({
 
   // Can be used to adjust node size if/when this feature is implemented
   const nodeSize = isExpanded ? 3.5 : 3.5;
-  const markerStartSize = 2;
   return (
     <div className={isExpanded ? 'expanded-diagram' : 'mini-diagram'}>
       <svg width={size.width} height={size.height}>
@@ -403,22 +397,6 @@ export default function EntityDiagram({
             refY={nodeSize}
           >
             <circle cx={nodeSize} cy={nodeSize} r={nodeSize} />
-          </marker>
-          <marker
-            id="dot-start"
-            viewBox="0 0 10 10"
-            markerWidth={markerStartSize}
-            markerHeight={markerStartSize}
-            orient="auto"
-            fill="#777"
-            refX={markerStartSize + 0.5}
-            refY={markerStartSize}
-          >
-            <circle
-              cx={markerStartSize}
-              cy={markerStartSize}
-              r={markerStartSize}
-            />
           </marker>
           <filter id="shadow" x="-20%" y="-40%" width="150%" height="200%">
             <feDropShadow

--- a/src/EntityDiagram/EntityDiagram.tsx
+++ b/src/EntityDiagram/EntityDiagram.tsx
@@ -49,6 +49,7 @@ export interface StudyData {
   displayNamePlural?: string;
   description: string;
   children?: this[];
+  isManyToOneWithParent?: boolean;
   variables: Variables[];
 }
 
@@ -298,12 +299,8 @@ export default function EntityDiagram({
     orientation,
   }: OffsetLine) {
     let to: NodePoint, from: NodePoint;
-    const oneToManyEntityIDs = [
-      'EUPATH_0000776',
-      'EUPATH_0000738',
-      'EUPATH_0043226',
-    ];
-    const isOneToMany = oneToManyEntityIDs.includes(link.target.data.id);
+
+    const isOneToMany = link.target.data.isManyToOneWithParent;
 
     // TODO Compute angle of line so it points into center of node or edge,
     // but begins in same place as now. Use pythagorean theorem to compute
@@ -381,7 +378,7 @@ export default function EntityDiagram({
   }
 
   // Can be used to adjust node size if/when this feature is implemented
-  const nodeSize = isExpanded ? 4.5 : 3.5;
+  const nodeSize = isExpanded ? 4.25 : 3.5;
   return (
     <div className={isExpanded ? 'expanded-diagram' : 'mini-diagram'}>
       <svg width={size.width} height={size.height}>

--- a/src/EntityDiagram/EntityDiagram.tsx
+++ b/src/EntityDiagram/EntityDiagram.tsx
@@ -358,7 +358,7 @@ export default function EntityDiagram({
           from={from}
           to={to}
           stroke="#777"
-          strokeWidth={3}
+          strokeWidth={2}
           markerStart={'url(#dot)'}
           markerEnd={isOneToMany ? '' : 'url(#dot)'}
         />
@@ -370,7 +370,7 @@ export default function EntityDiagram({
                   from={to}
                   to={endpoint}
                   stroke="#777"
-                  strokeWidth={3}
+                  strokeWidth={2}
                   markerEnd="url(#dot)"
                 />
               );
@@ -381,7 +381,7 @@ export default function EntityDiagram({
   }
 
   // Can be used to adjust node size if/when this feature is implemented
-  const nodeSize = isExpanded ? 3.5 : 3.5;
+  const nodeSize = isExpanded ? 4.5 : 3.5;
   return (
     <div className={isExpanded ? 'expanded-diagram' : 'mini-diagram'}>
       <svg width={size.width} height={size.height}>


### PR DESCRIPTION
Addresses issue #326

Current code is hardcoded to only render repeated measures as a 1:many relationship. I will update when backend includes the necessary fields/properties.

The current implementation looks as follows:
**Amazonia ICEMR Brazil Cohor**
![image](https://user-images.githubusercontent.com/69446567/161287312-fd9fff74-35a6-4b50-b639-cfbdfaa74417.png)

**GEMS1 Case Control**
![image](https://user-images.githubusercontent.com/69446567/161287918-cd6e9644-e111-44a6-8739-e559f2101d34.png)
