### PR TITLE
Switch chart markers to use barplot; add display labels to RadioButtonGroup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/components",
-  "version": "0.14.5",
+  "version": "0.15.0",
   "license": "Apache-2.0",
   "description": "React Components for VEuPathDB Websites",
   "repository": {

--- a/src/components/widgets/RadioButtonGroup.tsx
+++ b/src/components/widgets/RadioButtonGroup.tsx
@@ -1,5 +1,5 @@
 // widget for radio button group
-import React from 'react';
+import React, { ReactNode } from 'react';
 import Radio from '@material-ui/core/Radio';
 import RadioGroup from '@material-ui/core/RadioGroup';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
@@ -13,6 +13,8 @@ export type RadioButtonGroupProps = {
   orientation?: 'vertical' | 'horizontal';
   /** Options that will be presented as buttons. */
   options: Array<string>;
+  /** Optional display labels for the options (otherwise the `options` array will be used) */
+  optionLabels?: Array<ReactNode>;
   /** The currently selected option.  */
   selectedOption: string;
   /** Action to take when an option is selected by the user. */
@@ -41,6 +43,7 @@ export default function RadioButtonGroup({
   label = undefined,
   orientation = 'horizontal',
   options,
+  optionLabels,
   selectedOption,
   onOptionSelected,
   containerStyles = {},
@@ -91,7 +94,11 @@ export default function RadioButtonGroup({
             <FormControlLabel
               key={index}
               value={option}
-              label={option}
+              label={
+                optionLabels != null && optionLabels.length === options.length
+                  ? optionLabels[index]
+                  : option
+              }
               disabled={disabledList?.includes(option)}
               labelPlacement={labelPlacement}
               // primary: blue; secondary: red

--- a/src/map/ChartMarker.tsx
+++ b/src/map/ChartMarker.tsx
@@ -240,7 +240,6 @@ export default function ChartMarker(props: ChartMarkerProps) {
         ],
       }}
       orientation="vertical"
-      barLayout="stack"
       containerStyles={{
         width: plotSize + 'px',
         height: plotSize + 'px',
@@ -259,6 +258,7 @@ export default function ChartMarker(props: ChartMarkerProps) {
       // dependentAxisRange is an object with {min, max} (NumberRange)
       dependentAxisRange={props.dependentAxisRange ?? undefined}
       showValues={true}
+      showIndependentAxisTickLabel={false}
     />
   );
 

--- a/src/map/ChartMarker.tsx
+++ b/src/map/ChartMarker.tsx
@@ -73,6 +73,11 @@ export default function ChartMarker(props: ChartMarkerProps) {
     .reduce((a, c) => {
       return a + c;
     }); // summation of fullStat.value per marker icon
+  const sumValuesString =
+    sumValues <= 0.99 && sumValues > 0
+      ? sumValues.toFixed(2)
+      : sumValues.toFixed(0);
+
   var maxValues: number = Math.max(...fullStat.map((o) => o.value)); // max of fullStat.value per marker icon
   // for local max, need to check the case wherer all values are zeros that lead to maxValues equals to 0 -> "divided by 0" can happen
   if (maxValues == 0) {
@@ -194,7 +199,7 @@ export default function ChartMarker(props: ChartMarkerProps) {
     '<text x="50%" y=' +
     (size - 2 + borderWidth + 7) +
     ' dominant-baseline="middle" text-anchor="middle" opacity="1">' +
-    sumValues +
+    sumValuesString +
     '</text>';
 
   // check isAtomic: draw pushpin if true
@@ -254,7 +259,7 @@ export default function ChartMarker(props: ChartMarkerProps) {
       displayLibraryControls={false}
       interactive={false}
       dependentAxisLabel=""
-      independentAxisLabel={`Total: ${sumValues.toString()}`}
+      independentAxisLabel={`Total: ${sumValuesString}`}
       // dependentAxisRange is an object with {min, max} (NumberRange)
       dependentAxisRange={props.dependentAxisRange ?? undefined}
       showValues={true}

--- a/src/map/ChartMarker.tsx
+++ b/src/map/ChartMarker.tsx
@@ -2,16 +2,19 @@ import React from 'react';
 import L from 'leaflet';
 
 import BoundsDriftMarker, { BoundsDriftMarkerProps } from './BoundsDriftMarker';
-import Histogram from '../plots/Histogram';
+import Barplot from '../plots/Barplot';
+//import Histogram from '../plots/Histogram';
 // import NumberRange type def
 import { NumberRange } from '../types/general';
 
 interface ChartMarkerProps extends BoundsDriftMarkerProps {
   borderColor?: string;
   borderWidth?: number;
-  labels: Array<string>; // the labels (not likely to be shown at normal marker size)
-  values: Array<number>; // the counts or totals to be shown in the donut
-  colors?: Array<string> | null; // bar colors: set to be optional with array or null type
+  data: {
+    value: number;
+    label: string;
+    color?: string;
+  }[];
   isAtomic?: boolean; // add a special thumbtack icon if this is true (it's a marker that won't disaggregate if zoomed in further)
   // changed to dependentAxisRange
   dependentAxisRange?: NumberRange | null; // y-axis range for setting global max
@@ -30,9 +33,9 @@ export default function ChartMarker(props: ChartMarkerProps) {
   let defaultColor: string = '';
   let defaultLineColor: string = '';
   // need to make a temporary stats array of objects to show marker colors - only works for demo data, not real solr data
-  for (let i = 0; i < props.values.length; i++) {
-    if (props.colors) {
-      defaultColor = props.colors[i];
+  for (let i = 0; i < props.data.length; i++) {
+    if (props.data[i].color != null) {
+      defaultColor = props.data[i].color as string;
       // defaultLineColor = 'grey'       // this is outline of histogram
       defaultLineColor = '#00000088'; // this is outline of histogram
     } else {
@@ -42,8 +45,8 @@ export default function ChartMarker(props: ChartMarkerProps) {
     fullStat.push({
       // color: props.colors[i],
       color: defaultColor,
-      label: props.labels[i],
-      value: props.values[i],
+      label: props.data[i].label,
+      value: props.data[i].value,
     });
   }
 
@@ -225,20 +228,16 @@ export default function ChartMarker(props: ChartMarkerProps) {
   const popupSize = plotSize + 2 * marginSize;
 
   const popupPlot = (
-    <Histogram
+    <Barplot
       data={{
-        series: props.labels.map((label, i) => ({
-          name: label,
-          color: props.colors ? props.colors[i] : undefined,
-          bins: [
-            {
-              binStart: i,
-              binEnd: i + 1,
-              binLabel: label,
-              value: props.values[i],
-            },
-          ],
-        })),
+        series: [
+          {
+            name: 'do not display me',
+            label: props.data.map(({ label }) => label),
+            value: props.data.map(({ value }) => value),
+            color: props.data.map(({ color }) => color ?? ''),
+          },
+        ],
       }}
       orientation="vertical"
       barLayout="stack"

--- a/src/stories/api/getMarkersFromFixtureData.tsx
+++ b/src/stories/api/getMarkersFromFixtureData.tsx
@@ -300,18 +300,18 @@ export const getCollectionDateChartMarkers = async (
       southWest: { lat: bucket.ltMin, lng: bucket.lnMin },
       northEast: { lat: bucket.ltMax, lng: bucket.lnMax },
     };
-    let labels = [];
-    let values = [];
-    let colors: string[] = [];
+    let markerData = [];
     let noDataValue: number = 0;
     bucket.term.buckets.forEach(
       (bucket: { count: number; val: string }, index: number) => {
         const start = bucket.val.substring(0, 4);
         const end = parseInt(start, 10) + 3;
         const label = `${start}-${end}`;
-        labels.push(label);
-        values.push(bucket.count);
-        colors.push(chartMarkerColorsHex[index]);
+        markerData.push({
+          label,
+          count: bucket.count,
+          color: chartMarkerColorsHex[index],
+        });
 
         // sum all counts for legend
         if (legendSums[index] == null) {
@@ -325,10 +325,11 @@ export const getCollectionDateChartMarkers = async (
 
     // calculate the number of no data (or data before first bin, or after last bin) and make 6th bar
     noDataValue = bucket.count - bucket.term.between.count;
-    labels.push('noDataOrOutOfBounds');
-    values.push(noDataValue);
-    colors.push('silver'); // fill the last color
-
+    markerData.push({
+      label: 'noDataOrOutOfBounds',
+      value: noDataValue,
+      color: 'silver', // fill the last color
+    });
     legendLabels[5] = 'no data/out of bounds';
     if (legendSums[5] == null) legendSums[5] = 0;
     legendSums[5] += noDataValue;
@@ -354,9 +355,7 @@ export const getCollectionDateChartMarkers = async (
         key={key}
         position={{ lat, lng }}
         bounds={bounds}
-        labels={labels}
-        values={values}
-        colors={colors}
+        data={markerData}
         isAtomic={atomicValue}
         // dependentAxisRange is an object with {min,max} (NumberRange)
         dependentAxisRange={
@@ -425,10 +424,6 @@ export const getCollectionDateBasicMarkers = async (
       northEast: { lat: bucket.ltMax, lng: bucket.lnMax },
     };
 
-    const labels = ['count'];
-    const values = [bucket.count];
-    const colors: string[] = ['white'];
-
     // check isAtomic for push pin for chart marker
     const atomicValue =
       bucket.atomicCount && bucket.atomicCount === 1 ? true : false;
@@ -446,9 +441,13 @@ export const getCollectionDateBasicMarkers = async (
         key={key}
         position={{ lat, lng }}
         bounds={bounds}
-        labels={labels}
-        values={values}
-        colors={colors}
+        data={[
+          {
+            label: 'count',
+            value: bucket.count,
+            color: 'white',
+          },
+        ]}
         isAtomic={atomicValue}
         // change to dependentAxisRange
         dependentAxisRange={null}

--- a/src/stories/api/getMarkersFromFixtureData.tsx
+++ b/src/stories/api/getMarkersFromFixtureData.tsx
@@ -309,7 +309,7 @@ export const getCollectionDateChartMarkers = async (
         const label = `${start}-${end}`;
         markerData.push({
           label,
-          count: bucket.count,
+          value: bucket.count,
           color: chartMarkerColorsHex[index],
         });
 

--- a/src/stories/widgets/RadioButtonGroup.stories.tsx
+++ b/src/stories/widgets/RadioButtonGroup.stories.tsx
@@ -34,3 +34,9 @@ Basic.args = {
   margins: ['10em', '0', '0', '10em'],
   itemMarginRight: 50,
 };
+
+export const Renamed = Template.bind({});
+Renamed.args = {
+  ...Basic.args,
+  optionLabels: ['Sideways', 'Upright'],
+};

--- a/src/types/plots/barplot.ts
+++ b/src/types/plots/barplot.ts
@@ -2,7 +2,7 @@ export type BarplotDataSeries = {
   /** The name of the data. e.g. 'male' or 'female' */
   name: string;
   /** The color of the data. Optional. */
-  color?: string;
+  color?: string | string[];
   /** The color of the bar outline. Optional. */
   borderColor?: string;
   /** The values that make the height of the bars */


### PR DESCRIPTION
The enlarged popups for ChartMarkers now use Barplot instead of Histogram. 
Also allowed an array of colors (per series) to be passed to Barplot. This should not affect regular barplots.
Also added optionLabels to RadioButtonGroup - I added a Story for this but was unable to get Storybook running on my laptop (white browser window - no errors in the terminal (forgot to check the FF console)).