### PR TITLE
Introduce TypeScript-based map config (resolves #324)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/components",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "license": "Apache-2.0",
   "description": "React Components for VEuPathDB Websites",
   "repository": {

--- a/src/map/config/map.ts
+++ b/src/map/config/map.ts
@@ -1,0 +1,35 @@
+// N.B.: This config should be used in place of ./map.json,
+// which is deprecated.
+// (Context: https://github.com/VEuPathDB/web-components/issues/324)
+
+export const defaultAnimationDuration = 300;
+
+export const allColorsHex = [
+  '#FFB300',
+  '#803E75',
+  '#FF6800',
+  '#A6BDD7',
+  '#C10020',
+  '#CEA262',
+  '#007D34',
+  '#F6768E',
+  '#00538A',
+  '#FF7A5C',
+  '#53377A',
+  '#FF8E00',
+  '#B32851',
+  '#F4C800',
+  '#7F180D',
+  '#93AA00',
+  '#593315',
+  '#F13A13',
+  '#232C16',
+];
+
+export const chartMarkerColorsHex = [
+  '#0018A9',
+  '#3B1988',
+  '#771A66',
+  '#B21B45',
+  '#ED1C23',
+];

--- a/src/stories/AnimatedMarkers.stories.tsx
+++ b/src/stories/AnimatedMarkers.stories.tsx
@@ -8,7 +8,7 @@ import BoundsDriftMarker, {
   BoundsDriftMarkerProps,
 } from '../map/BoundsDriftMarker';
 import geohashAnimation from '../map/animation_functions/geohash';
-import { defaultAnimationDuration } from '../map/config/map.json';
+import { defaultAnimationDuration } from '../map/config/map';
 import { leafletZoomLevelToGeohashLevel } from '../map/utils/leaflet-geohash';
 import { Viewport } from 'react-leaflet';
 

--- a/src/stories/ChartMarkers.stories.tsx
+++ b/src/stories/ChartMarkers.stories.tsx
@@ -4,7 +4,7 @@ import { Story, Meta } from '@storybook/react/types-6-0';
 import MapVEuMap, { MapVEuMapProps } from '../map/MapVEuMap';
 import { BoundsViewport } from '../map/Types';
 import { BoundsDriftMarkerProps } from '../map/BoundsDriftMarker';
-import { defaultAnimationDuration } from '../map/config/map.json';
+import { defaultAnimationDuration } from '../map/config/map';
 import { leafletZoomLevelToGeohashLevel } from '../map/utils/leaflet-geohash';
 import { Viewport } from 'react-leaflet';
 import {

--- a/src/stories/DonutMarkers.stories.tsx
+++ b/src/stories/DonutMarkers.stories.tsx
@@ -3,7 +3,7 @@ import { Story, Meta } from '@storybook/react/types-6-0';
 // import { action } from '@storybook/addon-actions';
 import { BoundsViewport } from '../map/Types';
 import { BoundsDriftMarkerProps } from '../map/BoundsDriftMarker';
-import { defaultAnimationDuration } from '../map/config/map.json';
+import { defaultAnimationDuration } from '../map/config/map';
 import { leafletZoomLevelToGeohashLevel } from '../map/utils/leaflet-geohash';
 import {
   getSpeciesDonuts,

--- a/src/stories/Map.stories.tsx
+++ b/src/stories/Map.stories.tsx
@@ -3,7 +3,7 @@ import { Story, Meta } from '@storybook/react/types-6-0';
 // import { action } from '@storybook/addon-actions';
 import { BoundsViewport } from '../map/Types';
 import { BoundsDriftMarkerProps } from '../map/BoundsDriftMarker';
-import { defaultAnimationDuration } from '../map/config/map.json';
+import { defaultAnimationDuration } from '../map/config/map';
 import { leafletZoomLevelToGeohashLevel } from '../map/utils/leaflet-geohash';
 import { getSpeciesDonuts } from './api/getMarkersFromFixtureData';
 

--- a/src/stories/MultipleWorlds.stories.tsx
+++ b/src/stories/MultipleWorlds.stories.tsx
@@ -7,7 +7,7 @@ import MapVEuMap, { MapVEuMapProps } from '../map/MapVEuMap';
 import geohashAnimation from '../map/animation_functions/geohash';
 import testDataStraddling from './fixture-data/geoclust-date-dateline-straddling-all-levels.json';
 import BoundsDriftMarker from '../map/BoundsDriftMarker';
-import { defaultAnimationDuration } from '../map/config/map.json';
+import { defaultAnimationDuration } from '../map/config/map';
 import { leafletZoomLevelToGeohashLevel } from '../map/utils/leaflet-geohash';
 import { Viewport } from 'react-leaflet';
 import '../map/TempIconHack';

--- a/src/stories/SidebarResize.stories.tsx
+++ b/src/stories/SidebarResize.stories.tsx
@@ -4,7 +4,7 @@ import { Story, Meta } from '@storybook/react/types-6-0';
 // import MapVEuMap from './MapVEuMap';
 import { BoundsViewport, Bounds } from '../map/Types';
 import { BoundsDriftMarkerProps } from '../map/BoundsDriftMarker';
-import { defaultAnimationDuration } from '../map/config/map.json';
+import { defaultAnimationDuration } from '../map/config/map';
 import { Viewport } from 'react-leaflet';
 
 //let's use new approach for data retrieval

--- a/src/stories/api/getMarkersFromFixtureData.tsx
+++ b/src/stories/api/getMarkersFromFixtureData.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BoundsViewport, Bounds } from '../../map/Types';
-import { allColorsHex, chartMarkerColorsHex } from '../../map/config/map.json';
+import { allColorsHex, chartMarkerColorsHex } from '../../map/config/map';
 import { leafletZoomLevelToGeohashLevel } from '../../map/utils/leaflet-geohash';
 import DonutMarker, { DonutMarkerProps } from '../../map/DonutMarker';
 import ChartMarker from '../../map/ChartMarker';


### PR DESCRIPTION
Resolves #324.

I have left the old `map.json` in place, so as to avoid making a breaking change. We should remove `map.json` in the next major release of `@veupathdb/web-components`.