### PR TITLE
add a prop for handling no smoothing at scatter Viz

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/components",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "license": "Apache-2.0",
   "description": "React Components for VEuPathDB Websites",
   "repository": {

--- a/src/components/widgets/LabelledGroup.tsx
+++ b/src/components/widgets/LabelledGroup.tsx
@@ -43,7 +43,7 @@ export default function LabelledGroup(props: LabelledGroupProps) {
         {label && (
           <Typography
             variant="button"
-            style={{ color: '#000000', fontWeight: 'bold', fontSize: '1.2em' }}
+            style={{ color: '#222', fontWeight: 500, fontSize: '1.2em' }}
           >
             {label}
           </Typography>

--- a/src/components/widgets/LabelledGroup.tsx
+++ b/src/components/widgets/LabelledGroup.tsx
@@ -43,7 +43,7 @@ export default function LabelledGroup(props: LabelledGroupProps) {
         {label && (
           <Typography
             variant="button"
-            style={{ color: '#000000', fontWeight: 'bold' }}
+            style={{ color: '#000000', fontWeight: 'bold', fontSize: '1.2em' }}
           >
             {label}
           </Typography>

--- a/src/components/widgets/NumberAndDateInputs.tsx
+++ b/src/components/widgets/NumberAndDateInputs.tsx
@@ -182,7 +182,7 @@ function BaseInput({
       {label && (
         <Typography
           variant="button"
-          style={{ color: disabled ? MEDIUM_GRAY : 'black' }}
+          style={{ color: disabled ? MEDIUM_GRAY : '#222' }}
         >
           {label}
         </Typography>

--- a/src/components/widgets/NumberAndDateRangeInputs.tsx
+++ b/src/components/widgets/NumberAndDateRangeInputs.tsx
@@ -167,7 +167,7 @@ function BaseInput({
       {label && (
         <Typography
           variant="button"
-          style={{ color: disabled ? MEDIUM_GRAY : 'black' }}
+          style={{ color: disabled ? MEDIUM_GRAY : '#222' }}
         >
           {label}
         </Typography>
@@ -215,7 +215,7 @@ function BaseInput({
           >
             <Typography
               variant="button"
-              style={{ color: disabled ? MEDIUM_GRAY : 'black' }}
+              style={{ color: disabled ? MEDIUM_GRAY : '#222' }}
             >
               to
             </Typography>

--- a/src/components/widgets/RadioButtonGroup.tsx
+++ b/src/components/widgets/RadioButtonGroup.tsx
@@ -75,7 +75,7 @@ export default function RadioButtonGroup({
           variant="button"
           // perhaps not using focused?
           // style={{ color: focused ? DARK_GRAY : MEDIUM_GRAY }}
-          style={{ color: '#000000', fontWeight: 'bold' }}
+          style={{ color: '#000000', fontWeight: 'bold', fontSize: '1.2em' }}
         >
           {label}
         </Typography>

--- a/src/components/widgets/RadioButtonGroup.tsx
+++ b/src/components/widgets/RadioButtonGroup.tsx
@@ -75,7 +75,7 @@ export default function RadioButtonGroup({
           variant="button"
           // perhaps not using focused?
           // style={{ color: focused ? DARK_GRAY : MEDIUM_GRAY }}
-          style={{ color: '#000000', fontWeight: 'bold', fontSize: '1.2em' }}
+          style={{ color: '#222', fontWeight: 500, fontSize: '1.2em' }}
         >
           {label}
         </Typography>

--- a/src/types/plots/scatterplot.ts
+++ b/src/types/plots/scatterplot.ts
@@ -38,6 +38,8 @@ export type ScatterPlotDataSeries = {
   r2?: number;
   /** opacity of points? */
   opacity?: number;
+  /** add a prop to check whether smoothed mean exists */
+  hasSmoothedMeanData?: boolean;
 };
 
 export type ScatterPlotData = {


### PR DESCRIPTION
This is related to a web-eda PR, https://github.com/VEuPathDB/web-eda/pull/1032

The purpose of this work is to have an additional prop, which will be used to examine whether the data has no smoothed mean and use the info to show/hide message.

There is another minor request involved in this PR, which is to increase the title of axis range control, e.g., Y-axis controls to be the same same font and size as the text for "Axis variables" and "Stratification variables". https://github.com/VEuPathDB/web-eda/issues/1011#issuecomment-1097035678 and https://github.com/VEuPathDB/web-eda/issues/1011#issuecomment-1097045514 