### PR TITLE
replacing some baselayers for making thumbnails correctly

### DIFF
--- a/src/map/MapVEuMap.tsx
+++ b/src/map/MapVEuMap.tsx
@@ -97,6 +97,18 @@ export const baseLayers = {
     // maxZoom='18'
     // noWrap='0'
   },
+  Terrain_Alt1: {
+    url: 'https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png',
+    attribution:
+      'Map data: &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, <a href="http://viewfinderpanoramas.org">SRTM</a> | Map style: &copy; <a href="https://opentopomap.org">OpenTopoMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)',
+    maxZoom: 17,
+  },
+  Light_Alt1: {
+    url: 'https://tiles.stadiamaps.com/tiles/alidade_smooth/{z}/{x}/{y}{r}.png',
+    attribution:
+      '&copy; <a href="https://stadiamaps.com/">Stadia Maps</a>, &copy; <a href="https://openmaptiles.org/">OpenMapTiles</a> &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors',
+    maxZoom: 20,
+  },
 };
 
 export type BaseLayerChoice = keyof typeof baseLayers;


### PR DESCRIPTION
This addresses https://github.com/VEuPathDB/web-eda/issues/1142. 

TL;DR: I recommend to switch two layers to another ones as temporarily added to the existing tilelayers, named as Terrain_Alt1 and Light_Alt1.

I have dug several parts of functions to figure out the reason why some tilelayers did not work for making thumbnails correctly, however, in a code wise, I could not spot on something special.

After testing more extensively, I figured it out that only two tilelayers such as Terrain and Light did not work out: the latter sometimes worked but was not that consistent. I recalled myself that the two titlelayers were relatively new ones to be added because previous ones seemed to be no longer supported. Those two come from the same provider, and I suspect that they are like an overlay style layer on top of OpenStreetMap layer: though I could not find that info, just my pure guess. Whenever making a thumbnail from one of the two tilelayers, it shows OpenStreetMap layer, not their own layer.

Accordingly, I tried to find alternatives for those two layers, which worked just fine for thumbnails without specific issue. FYI, below are screenshots of alternative tilelayers. If those are acceptable, then I will replace with them.

- Terrain alternative (more like topographic map)
![terrain2](https://user-images.githubusercontent.com/12802305/169406892-fbf41c07-0de3-42d2-9886-94697cd1afb2.png)

- Light alternative
![light2](https://user-images.githubusercontent.com/12802305/169406920-ed085612-8ea2-4bce-8141-657c3e3f8dc6.png)
