### PR TITLE
making log scales for both X and Y in the Scatter plot

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/components",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "license": "Apache-2.0",
   "description": "React Components for VEuPathDB Websites",
   "repository": {

--- a/src/types/plots/addOns.ts
+++ b/src/types/plots/addOns.ts
@@ -64,6 +64,12 @@ export type OpacityAddon = {
 };
 export const OpacityDefault: number = 0.5;
 
+export type independentAxisLogScaleAddon = {
+  /** Use a log scale for independent axis. Default is false */
+  independentAxisLogScale?: boolean;
+};
+export const independentAxisLogScaleDefault: boolean = false;
+
 export type DependentAxisLogScaleAddon = {
   /** Use a log scale for dependent axis. Default is false */
   dependentAxisLogScale?: boolean;


### PR DESCRIPTION
This makes log scale controls for both X and Y axes in the Scatter plot and its corresponding Viz. https://github.com/VEuPathDB/EdaNewIssues/issues/292

Since Scatter plot (and Viz) allow date variable at X and Y axes, it is configured to disable the log scale control when the selected variable is date type.

Here are example screenshots with explanation in the title: the same study and variables with the screenshot in the ticket were used for a comparison purpose.

- log scale is on for X-axis
![scatter-logscale1](https://user-images.githubusercontent.com/12802305/170138335-61b13c62-31fa-4819-8efc-5056146f238c.png)


- controlling legend to show/hide data: this may be useful for scattered data that show large range of confidence intervals in Y-axis.
![scatter-logscale2](https://user-images.githubusercontent.com/12802305/170138093-26f58a18-7487-4397-b0b3-753d74d7e8c2.png)

- A demo to show that log scale control at the Y-axis is disabled because its variable type is date
![scatter-logscale-date1](https://user-images.githubusercontent.com/12802305/170138172-2c13fa1b-a2f7-46a0-a401-3c879be61495.png)

