### PR TITLE
adding increased margin for scatterplot log scale

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/components",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "license": "Apache-2.0",
   "description": "React Components for VEuPathDB Websites",
   "repository": {

--- a/src/plots/ScatterPlot.tsx
+++ b/src/plots/ScatterPlot.tsx
@@ -87,7 +87,10 @@ const ScatterPlot = makePlotlyPlotComponent(
     const extendedDependentAxisRange = extendAxisRangeForTruncations(
       standardDependentAxisRange,
       axisTruncationConfig?.dependentAxis,
-      dependentValueType === 'date' ? 'date' : 'number'
+      dependentValueType === 'date' ? 'date' : 'number',
+      // adjust range for log scale
+      'scatterplot',
+      dependentAxisLogScale
     );
 
     // make rectangular layout shapes for truncated axis/missing data

--- a/src/utils/extended-axis-range-truncations.ts
+++ b/src/utils/extended-axis-range-truncations.ts
@@ -13,10 +13,14 @@ export function extendAxisRangeForTruncations(
   valueType?: 'number' | 'date',
   // set plot type to adjust padding/margin
   // histogram: no padding for X and Y; barplot: no min padding for Y
-  plotType?: string
+  plotType?: string,
+  logScale?: boolean
 ): NumberOrDateRange | undefined {
   // set this to avoid error
   if (axisRange == null) return undefined;
+
+  // adjust margin per log scale
+  const noTruncationMargin = logScale ? 0.3 : 0.02;
 
   // compute truncated axis with 5 % area from the range of min and max
   if (valueType != null) {
@@ -82,7 +86,7 @@ export function extendAxisRangeForTruncations(
         : // set exceptions: no need to have max padding for histogram
         plotType === 'histogram'
         ? (axisRange.max as number)
-        : (axisRange.max as number) + 0.02 * diff;
+        : (axisRange.max as number) + noTruncationMargin * diff;
 
       return {
         min: axisLowerExtensionStart,


### PR DESCRIPTION
This addresses a suggestion, https://github.com/VEuPathDB/web-eda/issues/1153#issuecomment-1142637556, which needs to increase margin for scatterplot log scale

After testing several cases, one of the simplest solution is to increase the margin when log scale is used. Screenshot is added for a comparison with Danica's screenshot at the comment above. As shown, marker is not cut in this implementation.

Note that this is only applied to max range of dependent axis because it would be most likely the case we need to consider.

![scatter-logscale-margin](https://user-images.githubusercontent.com/12802305/172456566-70b48c6e-fd59-4310-a09d-bafe482de77a.png)

