### PR TITLE
Map component: cancel debounce and use the debounced version for the 'one off' call too

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/components",
-  "version": "0.16.5",
+  "version": "0.16.6",
   "license": "Apache-2.0",
   "description": "React Components for VEuPathDB Websites",
   "repository": {

--- a/src/map/SemanticMarkers.tsx
+++ b/src/map/SemanticMarkers.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect, useState, cloneElement } from 'react';
+import { ReactElement, useEffect, useState, cloneElement } from 'react';
 import {
   MarkerProps,
   BoundsViewport,
@@ -62,14 +62,18 @@ export default function SemanticMarkers({
       }
     }
 
-    updateBounds();
-
     // debounce needed to avoid cyclic in/out zooming behaviour
     const debouncedUpdateBounds = debounce(updateBounds, 1000);
+    // call it at least once at the beginning of the life cycle
+    debouncedUpdateBounds();
+
+    // attach to leaflet events handler
     map.on('resize dragend zoomend', debouncedUpdateBounds); // resize is there hopefully when we have full screen mode
 
     return () => {
+      // detach from leaflet events handler
       map.off('resize dragend zoomend', debouncedUpdateBounds);
+      debouncedUpdateBounds.cancel();
     };
   }, [map, onBoundsChanged]);
 


### PR DESCRIPTION
Resolves #362 

I have tested this and it solves the 1 second exception, and changing `updateBounds()` to `debouncedUpdateBounds()`  doesn't cause any noticeable delay or increase the number of back-end requests.

@jernestmyers @moontrip and @chowington may be interested to see this small change (though I think I originally wrote the buggy code)