### PR TITLE
Experimental tiny map 

### DIFF
--- a/src/map/DonutMarker.tsx
+++ b/src/map/DonutMarker.tsx
@@ -20,6 +20,8 @@ export interface DonutMarkerProps extends BoundsDriftMarkerProps {
   onClick?: (event: L.LeafletMouseEvent) => void | undefined;
   /** center title/number for marker (defaults to sum of data[].value) */
   markerLabel?: string;
+  /** size of donut (default = 40) */
+  size?: number;
 }
 
 // DKDK convert to Cartesian coord. toCartesian(centerX, centerY, Radius for arc to draw, arc (radian))
@@ -115,7 +117,7 @@ export default function DonutMarker(props: DonutMarkerProps) {
   }
 
   //DKDK construct histogram marker icon
-  const size = 40; //DKDK SVG donut marker icon size: note that popbio/mapveu donut marker icons = 40
+  const size = props.size ?? 40;
   let svgHTML: string = ''; //DKDK divIcon HTML contents
 
   //DKDK set drawing area

--- a/src/map/MapVEuMap.tsx
+++ b/src/map/MapVEuMap.tsx
@@ -153,6 +153,13 @@ export interface MapVEuMapProps {
   baseLayer?: BaseLayerChoice;
   /** Callback for when the base layer has changed */
   onBaseLayerChanged?: (newBaseLayer: BaseLayerChoice) => void;
+  /** Show layers control, default true */
+  showLayerSelector?: boolean;
+  /** Show attribution, default true */
+  showAttribution?: boolean;
+  /** Show zoom control, default true */
+  showZoomControl?: boolean;
+
   /** Whether to zoom and pan map to center on markers */
   flyToMarkers?: boolean;
   /** How long (in ms) after rendering to wait before flying to markers */
@@ -186,6 +193,9 @@ function MapVEuMap(props: MapVEuMapProps, ref: Ref<PlotRef>) {
     showSpinner,
     showNoDataOverlay,
     showScale = true,
+    showLayerSelector = true,
+    showAttribution = true,
+    showZoomControl = true,
   } = props;
 
   // this is the React Map component's onViewPortChanged handler
@@ -327,6 +337,8 @@ function MapVEuMap(props: MapVEuMapProps, ref: Ref<PlotRef>) {
         onBaseLayerChanged && onBaseLayerChanged(event.name as BaseLayerChoice)
       }
       ref={mapRef}
+      attributionControl={showAttribution}
+      zoomControl={showZoomControl}
     >
       <TileLayer
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
@@ -348,18 +360,19 @@ function MapVEuMap(props: MapVEuMapProps, ref: Ref<PlotRef>) {
         <CustomGridLayer zoomLevelToGeohashLevel={zoomLevelToGeohashLevel} />
       ) : null}
 
-      <LayersControl position="topright">
-        {Object.entries(baseLayers).map(([name, layerProps], i) => (
-          <BaseLayer
-            name={name}
-            key={name}
-            checked={baseLayer ? name === baseLayer : i === 0}
-          >
-            <TileLayer {...layerProps} />
-          </BaseLayer>
-        ))}
-      </LayersControl>
-
+      {showLayerSelector && (
+        <LayersControl position="topright">
+          {Object.entries(baseLayers).map(([name, layerProps], i) => (
+            <BaseLayer
+              name={name}
+              key={name}
+              checked={baseLayer ? name === baseLayer : i === 0}
+            >
+              <TileLayer {...layerProps} />
+            </BaseLayer>
+          ))}
+        </LayersControl>
+      )}
       {showSpinner && <Spinner />}
       {showNoDataOverlay && <NoDataOverlay opacity={0.9} />}
       {/* add Scale in the map: currently set to show from zoom = 5 */}

--- a/src/map/utils/leaflet-geohash.ts
+++ b/src/map/utils/leaflet-geohash.ts
@@ -29,3 +29,35 @@ export function leafletZoomLevelToGeohashLevel(
       return 6;
   }
 }
+
+export function tinyLeafletZoomLevelToGeohashLevel(
+  leafletZoomLevel: number
+): number {
+  switch (leafletZoomLevel) {
+    case 1:
+    case 2:
+      return 2;
+    case 3:
+    case 4:
+    case 5:
+      return 3;
+    case 6:
+    case 7:
+    case 8:
+      return 4;
+    case 9:
+    case 10:
+    case 11:
+      return 5;
+    case 12:
+    case 13:
+    case 14:
+      return 6;
+    case 15:
+    case 16:
+    case 17:
+      return 6;
+    default:
+      return 6;
+  }
+}

--- a/src/stories/Map.stories.tsx
+++ b/src/stories/Map.stories.tsx
@@ -4,7 +4,10 @@ import { Story, Meta } from '@storybook/react/types-6-0';
 import { BoundsViewport } from '../map/Types';
 import { BoundsDriftMarkerProps } from '../map/BoundsDriftMarker';
 import { defaultAnimationDuration } from '../map/config/map';
-import { leafletZoomLevelToGeohashLevel } from '../map/utils/leaflet-geohash';
+import {
+  leafletZoomLevelToGeohashLevel,
+  tinyLeafletZoomLevelToGeohashLevel,
+} from '../map/utils/leaflet-geohash';
 import { getSpeciesDonuts } from './api/getMarkersFromFixtureData';
 
 import { LeafletMouseEvent } from 'leaflet';
@@ -183,7 +186,7 @@ export const Windowed: Story<MapVEuMapProps> = (args) => {
     ReactElement<BoundsDriftMarkerProps>[]
   >([]);
   const [legendData, setLegendData] = useState<LegendProps['data']>([]);
-  const [viewport] = useState<Viewport>({ center: [13, 16], zoom: 4 });
+  const [viewport] = useState<Viewport>({ center: [2, 16], zoom: 4 });
   const handleViewportChanged = useCallback(
     async (bvp: BoundsViewport) => {
       const markers = await getSpeciesDonuts(
@@ -229,4 +232,56 @@ Windowed.args = {
   },
   showGrid: true,
   showMouseToolbar: true,
+};
+
+export const Tiny: Story<MapVEuMapProps> = (args) => {
+  const [markerElements, setMarkerElements] = useState<
+    ReactElement<BoundsDriftMarkerProps>[]
+  >([]);
+  const [legendData, setLegendData] = useState<LegendProps['data']>([]);
+  const [viewport] = useState<Viewport>({ center: [8, 10], zoom: 2 });
+  const handleViewportChanged = useCallback(
+    async (bvp: BoundsViewport) => {
+      const markers = await getSpeciesDonuts(
+        bvp,
+        defaultAnimationDuration,
+        setLegendData,
+        handleMarkerClick,
+        0,
+        tinyLeafletZoomLevelToGeohashLevel,
+        20
+      );
+      setMarkerElements(markers);
+    },
+    [setMarkerElements]
+  );
+
+  return (
+    <>
+      <MapVEuMap
+        {...args}
+        viewport={viewport}
+        onBoundsChanged={handleViewportChanged}
+        markers={markerElements}
+        animation={defaultAnimation}
+        zoomLevelToGeohashLevel={tinyLeafletZoomLevelToGeohashLevel}
+      />
+    </>
+  );
+};
+
+Tiny.args = {
+  height: 110,
+  width: 220,
+  style: {
+    marginTop: 100,
+    marginLeft: 'auto',
+    marginRight: 'auto',
+  },
+  showGrid: false,
+  showMouseToolbar: false,
+  showScale: false,
+  showLayerSelector: false,
+  showAttribution: false,
+  showZoomControl: false,
 };

--- a/src/stories/api/getMarkersFromFixtureData.tsx
+++ b/src/stories/api/getMarkersFromFixtureData.tsx
@@ -17,9 +17,13 @@ export const getSpeciesDonuts = async (
     legendData: Array<{ label: string; value: number; color: string }>
   ) => void,
   handleMarkerClick: (e: LeafletMouseEvent) => void,
-  delay: number = 0
+  delay: number = 0,
+  zoomLevelToGeohashLevel: (
+    zoomLevel: number
+  ) => number = leafletZoomLevelToGeohashLevel,
+  donutSize: number = 40
 ) => {
-  const geohash_level = leafletZoomLevelToGeohashLevel(zoomLevel);
+  const geohash_level = zoomLevelToGeohashLevel(zoomLevel);
   delay && (await sleep(delay));
   const response = await fetch('data/geoclust-species-testing-all-levels.json');
   const speciesData = await response.json();
@@ -120,6 +124,8 @@ export const getSpeciesDonuts = async (
         isAtomic={atomicValue}
         onClick={handleMarkerClick}
         duration={duration}
+        size={donutSize}
+        markerLabel={donutSize < 40 ? '' : undefined}
       />
     );
   });


### PR DESCRIPTION
Quick hacky solution (but have added several new MapVEuMap props) to make a new story Map-->General-->Tiny

Which makes a tiny donut map with small markers, no numbers, and a finer-grained geohash mapping.

Could be part of the entity diagram in MapVEu-is-EDA.  I used it to create this [mock-up](https://docs.google.com/presentation/d/17Yg4Kz00pW6wbNo3bK0DpQjW4cVEzrq0VQ75pw1xZNc/edit#slide=id.g1333a64e1ab_0_5):

![image](https://user-images.githubusercontent.com/308639/174600943-a8ec475f-b1aa-40f8-bccc-4f3531a89bd7.png)
