### PR TITLE
Viz log range truncation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/components",
-  "version": "0.16.10",
+  "version": "0.17.0",
   "license": "Apache-2.0",
   "description": "React Components for VEuPathDB Websites",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@types/react-plotly.js": "^2.2.4",
     "@types/stats-lite": "^2.2.0",
     "@veupathdb/browserslist-config": "^1.0.0",
-    "@veupathdb/coreui": "^0.16.0",
+    "@veupathdb/coreui": "^0.17.8",
     "@veupathdb/eslint-config": "^1.0.0",
     "@veupathdb/prettier-config": "^1.0.0",
     "@veupathdb/tsconfig": "^1.0.1",
@@ -115,7 +115,7 @@
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.57",
-    "@veupathdb/coreui": "^0.16.0",
+    "@veupathdb/coreui": "^0.17.8",
     "react": ">=16.14"
   },
   "volta": {

--- a/src/components/plotControls/AxisRangeControl.tsx
+++ b/src/components/plotControls/AxisRangeControl.tsx
@@ -20,6 +20,8 @@ export interface AxisRangeControlProps
   onRangeChange?: (newRange?: NumberOrDateRange) => void;
   // add disabled prop to disable input fields
   disabled?: boolean;
+  /** is this for a log scale axis? If so, we'll validate the min value to be > 0 */
+  logScale?: boolean;
 }
 
 export default function AxisRangeControl({
@@ -30,26 +32,38 @@ export default function AxisRangeControl({
   containerStyles,
   // add disabled prop to disable input fields: default is false
   disabled = false,
+  logScale = false,
 }: AxisRangeControlProps) {
-  const validator = useCallback((range?: NumberOrDateRange): {
-    validity: boolean;
-    message: string;
-  } => {
-    if (range) {
-      if (range.min === range.max) {
-        return {
-          validity: false,
-          message: 'Start and end of range cannot be the same',
-        };
-      } else if (range.min > range.max) {
-        return {
-          validity: false,
-          message: 'End cannot be before start of range',
-        };
+  const validator = useCallback(
+    (
+      range?: NumberOrDateRange
+    ): {
+      validity: boolean;
+      message: string;
+    } => {
+      if (range) {
+        if (range.min === range.max) {
+          return {
+            validity: false,
+            message: 'Start and end of range cannot be the same',
+          };
+        } else if (range.min > range.max) {
+          return {
+            validity: false,
+            message: 'End cannot be before start of range',
+          };
+        } else if (logScale && range.min <= 0) {
+          return {
+            validity: false,
+            message:
+              'Range start should be greater than zero when using log scale',
+          };
+        }
       }
-    }
-    return { validity: true, message: '' };
-  }, []);
+      return { validity: true, message: '' };
+    },
+    [logScale]
+  );
 
   return onRangeChange ? (
     valueType != null && valueType === 'date' ? (

--- a/src/map/ChartMarker.tsx
+++ b/src/map/ChartMarker.tsx
@@ -7,7 +7,11 @@ import Barplot from '../plots/Barplot';
 // import NumberRange type def
 import { NumberRange } from '../types/general';
 
-interface ChartMarkerProps extends BoundsDriftMarkerProps {
+import { DependentAxisLogScaleAddon } from '../types/plots';
+
+interface ChartMarkerProps
+  extends BoundsDriftMarkerProps,
+    DependentAxisLogScaleAddon {
   borderColor?: string;
   borderWidth?: number;
   data: {
@@ -275,6 +279,7 @@ export default function ChartMarker(props: ChartMarkerProps) {
       dependentAxisRange={props.dependentAxisRange ?? undefined}
       showValues={true}
       showIndependentAxisTickLabel={false}
+      dependentAxisLogScale={props.dependentAxisLogScale}
     />
   );
 

--- a/src/plots/Barplot.tsx
+++ b/src/plots/Barplot.tsx
@@ -172,9 +172,9 @@ const Barplot = makePlotlyPlotComponent(
       axisTruncationConfig?.dependentAxis,
       'number',
       // set plot type not to have padding/margin on the min
-      'barplot'
+      'barplot',
+      dependentAxisLogScale
     ) as NumberRange | undefined;
-
     // make rectangular layout shapes for truncated axis/missing data
     const truncatedAxisHighlighting:
       | Partial<Shape>[]
@@ -221,9 +221,7 @@ const Barplot = makePlotlyPlotComponent(
             extendedDependentAxisRange?.max,
           ].map((val) =>
             dependentAxisLogScale && val != null
-              ? val <= 0
-                ? -0.1 // for count's logscale
-                : Math.log10(val as number)
+              ? Math.log10(val as number)
               : val
           )
         : [0, 10],

--- a/src/plots/Barplot.tsx
+++ b/src/plots/Barplot.tsx
@@ -172,7 +172,7 @@ const Barplot = makePlotlyPlotComponent(
       axisTruncationConfig?.dependentAxis,
       'number',
       // set plot type not to have padding/margin on the min
-      'barplot',
+      false,
       dependentAxisLogScale
     ) as NumberRange | undefined;
     // make rectangular layout shapes for truncated axis/missing data

--- a/src/plots/Barplot.tsx
+++ b/src/plots/Barplot.tsx
@@ -23,6 +23,7 @@ import { NumberRange } from '../types/general';
 // import truncation util functions
 import { extendAxisRangeForTruncations } from '../utils/extended-axis-range-truncations';
 import { truncationLayoutShapes } from '../utils/truncation-layout-shapes';
+import { logScaleDtick } from '../utils/logscale-dtick';
 
 // in this example, the main variable is 'country'
 export interface BarplotProps
@@ -226,7 +227,9 @@ const Barplot = makePlotlyPlotComponent(
               : val
           )
         : [0, 10],
-      dtick: dependentAxisLogScale ? 1 : undefined,
+      dtick: dependentAxisLogScale
+        ? logScaleDtick(extendedDependentAxisRange)
+        : undefined,
       showticklabels: showDependentAxisTickLabel,
     };
 

--- a/src/plots/Histogram.tsx
+++ b/src/plots/Histogram.tsx
@@ -34,6 +34,7 @@ import { Layout, Shape } from 'plotly.js';
 // import truncation util functions
 import { extendAxisRangeForTruncations } from '../utils/extended-axis-range-truncations';
 import { truncationLayoutShapes } from '../utils/truncation-layout-shapes';
+import { logScaleDtick } from '../utils/logscale-dtick';
 
 // bin middles needed for highlighting
 interface BinSummary {
@@ -474,7 +475,9 @@ const Histogram = makePlotlyPlotComponent(
               : val
           )
         : [0, 10],
-      dtick: dependentAxisLogScale ? 1 : undefined,
+      dtick: dependentAxisLogScale
+        ? logScaleDtick(extendedDependentAxisRange)
+        : undefined,
       tickfont: data.series.length ? {} : { color: 'transparent' },
       showline: !axisTruncationConfig?.independentAxis?.min,
       linecolor: '#dddddd',

--- a/src/plots/Histogram.tsx
+++ b/src/plots/Histogram.tsx
@@ -418,7 +418,8 @@ const Histogram = makePlotlyPlotComponent(
       axisTruncationConfig?.dependentAxis,
       'number',
       // set plot type not to have padding/margin on the min/max
-      'histogram'
+      'histogram',
+      dependentAxisLogScale
     ) as NumberRange | undefined;
 
     // make rectangular layout shapes for truncated axis/missing data

--- a/src/plots/Histogram.tsx
+++ b/src/plots/Histogram.tsx
@@ -376,9 +376,7 @@ const Histogram = makePlotlyPlotComponent(
     const extendedIndependentAxisRange = extendAxisRangeForTruncations(
       standardIndependentAxisRange,
       axisTruncationConfig?.independentAxis,
-      data.binWidthSlider?.valueType,
-      // set plot type not to have padding/margin on the min/max
-      'histogram'
+      data.binWidthSlider?.valueType
     );
 
     const plotlyIndependentAxisRange = [
@@ -418,7 +416,7 @@ const Histogram = makePlotlyPlotComponent(
       axisTruncationConfig?.dependentAxis,
       'number',
       // set plot type not to have padding/margin on the min/max
-      'histogram',
+      false,
       dependentAxisLogScale
     ) as NumberRange | undefined;
 

--- a/src/plots/LinePlot.tsx
+++ b/src/plots/LinePlot.tsx
@@ -82,7 +82,7 @@ const LinePlot = makePlotlyPlotComponent('LinePlot', (props: LinePlotProps) => {
     standardIndependentAxisRange,
     axisTruncationConfig?.independentAxis,
     independentValueType === 'date' ? 'date' : 'number',
-    'lineplot',
+    true, // addPadding
     independentAxisLogScale
   );
 
@@ -92,8 +92,7 @@ const LinePlot = makePlotlyPlotComponent('LinePlot', (props: LinePlotProps) => {
     standardDependentAxisRange,
     axisTruncationConfig?.dependentAxis,
     dependentValueType === 'date' ? 'date' : 'number',
-    // adjust range for log scale
-    'lineplot',
+    true, // addPadding
     dependentAxisLogScale
   );
 

--- a/src/plots/LinePlot.tsx
+++ b/src/plots/LinePlot.tsx
@@ -18,6 +18,7 @@ import {
 // import truncation util functions
 import { extendAxisRangeForTruncations } from '../utils/extended-axis-range-truncations';
 import { truncationLayoutShapes } from '../utils/truncation-layout-shapes';
+import { logScaleDtick } from '../utils/logscale-dtick';
 
 // is it possible to have this interface extend ScatterPlotProps?
 // or would we need some abstract layer, w scatter and line both as equal children below it?
@@ -148,7 +149,9 @@ const LinePlot = makePlotlyPlotComponent('LinePlot', (props: LinePlotProps) => {
           ? 'log'
           : undefined,
       tickfont: data.series.length ? {} : { color: 'transparent' },
-      dtick: independentAxisLogScale ? 1 : undefined,
+      dtick: independentAxisLogScale
+        ? logScaleDtick(extendedIndependentAxisRange)
+        : undefined,
     },
     yaxis: {
       title: dependentAxisLabel,
@@ -174,7 +177,9 @@ const LinePlot = makePlotlyPlotComponent('LinePlot', (props: LinePlotProps) => {
           ? 'log'
           : undefined,
       tickfont: data.series.length ? {} : { color: 'transparent' },
-      dtick: dependentAxisLogScale ? 1 : undefined,
+      dtick: dependentAxisLogScale
+        ? logScaleDtick(extendedDependentAxisRange)
+        : undefined,
     },
     // axis range control: add truncatedAxisHighlighting for layout.shapes
     shapes: truncatedAxisHighlighting,

--- a/src/plots/LinePlot.tsx
+++ b/src/plots/LinePlot.tsx
@@ -159,9 +159,7 @@ const LinePlot = makePlotlyPlotComponent('LinePlot', (props: LinePlotProps) => {
             extendedDependentAxisRange?.max,
           ].map((val) =>
             dependentAxisLogScale && val != null
-              ? val <= 0
-                ? -0.1 // for count's logscale
-                : Math.log10(val as number)
+              ? Math.log10(val as number)
               : val
           )
         : undefined,

--- a/src/plots/LinePlot.tsx
+++ b/src/plots/LinePlot.tsx
@@ -81,7 +81,9 @@ const LinePlot = makePlotlyPlotComponent('LinePlot', (props: LinePlotProps) => {
   const extendedIndependentAxisRange = extendAxisRangeForTruncations(
     standardIndependentAxisRange,
     axisTruncationConfig?.independentAxis,
-    independentValueType === 'date' ? 'date' : 'number'
+    independentValueType === 'date' ? 'date' : 'number',
+    'lineplot',
+    independentAxisLogScale
   );
 
   // truncation
@@ -132,9 +134,7 @@ const LinePlot = makePlotlyPlotComponent('LinePlot', (props: LinePlotProps) => {
             extendedIndependentAxisRange?.max,
           ].map((val) =>
             independentAxisLogScale && val != null
-              ? val <= 0
-                ? -0.1 // for count's logscale
-                : Math.log10(val as number)
+              ? Math.log10(val as number)
               : val
           )
         : undefined,

--- a/src/plots/ScatterPlot.tsx
+++ b/src/plots/ScatterPlot.tsx
@@ -158,12 +158,11 @@ const ScatterPlot = makePlotlyPlotComponent(
               extendedDependentAxisRange?.max,
             ].map((val) =>
               dependentAxisLogScale && val != null
-                ? val <= 0
-                  ? -0.1
-                  : Math.log10(val as number)
+                ? Math.log10(val as number)
                 : val
             )
           : undefined,
+        // range: undefined,
         zeroline: false, // disable xaxis line
         // make plot border
         mirror: true,

--- a/src/plots/ScatterPlot.tsx
+++ b/src/plots/ScatterPlot.tsx
@@ -81,7 +81,7 @@ const ScatterPlot = makePlotlyPlotComponent(
       standardIndependentAxisRange,
       axisTruncationConfig?.independentAxis,
       independentValueType === 'date' ? 'date' : 'number',
-      'scatterplot',
+      true, // addPadding
       independentAxisLogScale
     );
 
@@ -91,8 +91,7 @@ const ScatterPlot = makePlotlyPlotComponent(
       standardDependentAxisRange,
       axisTruncationConfig?.dependentAxis,
       dependentValueType === 'date' ? 'date' : 'number',
-      // adjust range for log scale
-      'scatterplot',
+      true, // addPadding
       dependentAxisLogScale
     );
 

--- a/src/plots/ScatterPlot.tsx
+++ b/src/plots/ScatterPlot.tsx
@@ -18,6 +18,7 @@ import { NumberOrDateRange } from '../types/general';
 // import truncation util functions
 import { extendAxisRangeForTruncations } from '../utils/extended-axis-range-truncations';
 import { truncationLayoutShapes } from '../utils/truncation-layout-shapes';
+import { logScaleDtick } from '../utils/logscale-dtick';
 
 export interface ScatterPlotProps
   extends PlotProps<ScatterPlotData>,
@@ -147,7 +148,9 @@ const ScatterPlot = makePlotlyPlotComponent(
             ? 'log'
             : undefined,
         tickfont: data.series.length ? {} : { color: 'transparent' },
-        dtick: independentAxisLogScale ? 1 : undefined,
+        dtick: independentAxisLogScale
+          ? logScaleDtick(extendedIndependentAxisRange)
+          : undefined,
       },
       yaxis: {
         title: dependentAxisLabel,
@@ -174,7 +177,9 @@ const ScatterPlot = makePlotlyPlotComponent(
             ? 'log'
             : undefined,
         tickfont: data.series.length ? {} : { color: 'transparent' },
-        dtick: dependentAxisLogScale ? 1 : undefined,
+        dtick: dependentAxisLogScale
+          ? logScaleDtick(extendedDependentAxisRange)
+          : undefined,
       },
       // add truncatedAxisHighlighting for layout.shapes
       shapes: truncatedAxisHighlighting,

--- a/src/plots/ScatterPlot.tsx
+++ b/src/plots/ScatterPlot.tsx
@@ -80,7 +80,9 @@ const ScatterPlot = makePlotlyPlotComponent(
     const extendedIndependentAxisRange = extendAxisRangeForTruncations(
       standardIndependentAxisRange,
       axisTruncationConfig?.independentAxis,
-      independentValueType === 'date' ? 'date' : 'number'
+      independentValueType === 'date' ? 'date' : 'number',
+      'scatterplot',
+      independentAxisLogScale
     );
 
     // truncation
@@ -131,9 +133,7 @@ const ScatterPlot = makePlotlyPlotComponent(
               extendedIndependentAxisRange?.max,
             ].map((val) =>
               independentAxisLogScale && val != null
-                ? val <= 0
-                  ? -0.1
-                  : Math.log10(val as number)
+                ? Math.log10(val as number)
                 : val
             )
           : undefined,

--- a/src/stories/ChartMarkers.stories.tsx
+++ b/src/stories/ChartMarkers.stories.tsx
@@ -20,6 +20,9 @@ import MapVEuLegendSampleList, {
 // anim
 import geohashAnimation from '../map/animation_functions/geohash';
 
+import LabelledGroup from '../components/widgets/LabelledGroup';
+import Switch from '../components/widgets/Switch';
+
 export default {
   title: 'Map/Chart Markers',
   component: MapVEuMap,
@@ -206,6 +209,85 @@ export const TwoRequests: Story<MapVEuMapProps> = (args) => {
 TwoRequests.args = {
   height: '100vh',
   width: '100vw',
+  showGrid: true,
+  showMouseToolbar: false, // not yet implemented
+};
+
+// dependent axis log scale story
+export const LogScale: Story<MapVEuMapProps> = (args) => {
+  const [markerElements, setMarkerElements] = useState<
+    ReactElement<BoundsDriftMarkerProps>[]
+  >([]);
+  const [legendData, setLegendData] = useState<LegendProps['data']>([]);
+  const [legendRadioValue, setLegendRadioValue] = useState<string>(
+    'Individual'
+  );
+  const [viewport] = useState<Viewport>({ center: [13, 0], zoom: 6 });
+
+  const legendRadioChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setLegendRadioValue(e.target.value);
+  };
+  const [dependentAxisRange, setDependentAxisRange] = useState<number[]>([
+    0,
+    0,
+  ]);
+
+  const legendType = 'numeric';
+
+  const duration = defaultAnimationDuration;
+
+  const [dependentAxisLogScale, setDependentAxisLogScale] = useState(false);
+
+  // send legendRadioValue instead of knob_YAxisRangeMethod: also send setYAxisRangeValue
+  const handleViewportChanged = useCallback(
+    async (bvp: BoundsViewport) => {
+      // anim add duration & scrambleKeys
+      const markers = await getCollectionDateChartMarkers(
+        bvp,
+        duration,
+        setLegendData,
+        handleMarkerClick,
+        legendRadioValue,
+        setDependentAxisRange,
+        0,
+        dependentAxisLogScale
+      );
+      setMarkerElements(markers);
+    },
+    [setMarkerElements, legendRadioValue, dependentAxisLogScale]
+  );
+
+  return (
+    <>
+      <MapVEuMap
+        {...args}
+        viewport={viewport}
+        onBoundsChanged={handleViewportChanged}
+        markers={markerElements}
+        showGrid={true}
+        showMouseToolbar={true}
+        animation={defaultAnimation}
+        zoomLevelToGeohashLevel={leafletZoomLevelToGeohashLevel}
+      />
+      {/* Y-axis range control */}
+      <div style={{ display: 'flex', flexDirection: 'row' }}>
+        <LabelledGroup label="Y-axis controls">
+          <div style={{ display: 'flex' }}>
+            <Switch
+              label="Log Scale:"
+              state={dependentAxisLogScale}
+              onStateChange={setDependentAxisLogScale}
+            />
+          </div>
+        </LabelledGroup>
+      </div>
+    </>
+  );
+};
+
+LogScale.args = {
+  height: '50vh',
+  width: '50vw',
   showGrid: true,
   showMouseToolbar: false, // not yet implemented
 };

--- a/src/stories/api/getMarkersFromFixtureData.tsx
+++ b/src/stories/api/getMarkersFromFixtureData.tsx
@@ -230,7 +230,8 @@ export const getCollectionDateChartMarkers = async (
   handleMarkerClick: (e: LeafletMouseEvent) => void,
   legendRadioValue: string,
   setDependentAxisRange: (dependentAxisRange: number[]) => void,
-  delay: number = 0
+  delay: number = 0,
+  dependentAxisLogScale?: boolean
 ) => {
   const geohash_level = leafletZoomLevelToGeohashLevel(zoomLevel);
   delay && (await sleep(delay));
@@ -365,6 +366,7 @@ export const getCollectionDateChartMarkers = async (
         }
         duration={duration}
         onClick={handleMarkerClick}
+        dependentAxisLogScale={dependentAxisLogScale}
       />
     );
   });

--- a/src/types/guards.ts
+++ b/src/types/guards.ts
@@ -55,9 +55,16 @@ export function isLinePlotData(
     : false;
 }
 
+/** WARNING - THIS IS NOT A GOOD TEST. Date("22") is a valid date
+ * luckily it's not used in any production code
+ */
 /** Determine if a NumberOrDate variable is a string that can be converted to a date */
 export function isDate(date: NumberOrDate): date is string {
   return new Date(date as string).toString() !== 'Invalid Date';
+}
+
+export function isNumber(x: any): x is number {
+  return typeof x === 'number';
 }
 
 /** Determine if a date/time quantity is a TimeUnit */

--- a/src/utils/extended-axis-range-truncations.ts
+++ b/src/utils/extended-axis-range-truncations.ts
@@ -76,7 +76,9 @@ export function extendAxisRangeForTruncations(
       // consider padding
       const diff = (axisRange.max as number) - (axisRange.min as number);
       const axisLowerExtensionStart = config?.min
-        ? (axisRange.min as number) - 0.05 * diff
+        ? logScale && (axisRange.min as number) - 0.05 * diff <= 0
+          ? (axisRange.min as number) - (axisRange.min as number) / 2.5
+          : (axisRange.min as number) - 0.05 * diff
         : // set exceptions: no need to have min padding for histogram & barplot (boxplot?)
         plotType === 'histogram' || plotType === 'barplot'
         ? (axisRange.min as number)

--- a/src/utils/extended-axis-range-truncations.ts
+++ b/src/utils/extended-axis-range-truncations.ts
@@ -13,8 +13,8 @@ export function extendAxisRangeForTruncations(
   valueType?: 'number' | 'date',
   // set plot type to adjust padding/margin
   // histogram: no padding for X and Y; barplot: no min padding for Y
-  plotType?: string,
-  logScale?: boolean
+  addPadding: boolean = false,
+  logScale: boolean = false
 ): NumberOrDateRange | undefined {
   // set this to avoid error
   if (axisRange == null) return undefined;
@@ -48,10 +48,9 @@ export function extendAxisRangeForTruncations(
         // padding: check truncation or not
         config?.min
           ? dateRangeDiff
-          : plotType === 'histogram'
-          ? // no padding/margin
-            0
-          : dateRangeDiffNoTruncation,
+          : addPadding
+          ? dateRangeDiffNoTruncation
+          : 0,
         'hours'
       ).toISOString();
 
@@ -61,10 +60,9 @@ export function extendAxisRangeForTruncations(
         // padding: check truncation or not
         config?.max
           ? dateRangeDiff
-          : plotType === 'histogram'
-          ? // no padding/margin
-            0
-          : dateRangeDiffNoTruncation,
+          : addPadding
+          ? dateRangeDiffNoTruncation
+          : 0,
         'hours'
       ).toISOString();
 
@@ -81,8 +79,7 @@ export function extendAxisRangeForTruncations(
           ? (axisRange.min as number) /
             10 ** (truncationMarginFactor * Math.log10(ratio))
           : (axisRange.min as number) - truncationMarginFactor * diff
-        : // set exceptions: no need to have min padding for histogram & barplot (boxplot?)
-        plotType === 'histogram' || plotType === 'barplot'
+        : !addPadding
         ? (axisRange.min as number)
         : logScale && isFinite(ratio) && ratio > 0
         ? (axisRange.min as number) /
@@ -93,8 +90,7 @@ export function extendAxisRangeForTruncations(
           ? (axisRange.max as number) *
             10 ** (truncationMarginFactor * Math.log10(ratio))
           : (axisRange.max as number) + truncationMarginFactor * diff
-        : // set exceptions: no need to have max padding for histogram
-        plotType === 'histogram'
+        : !addPadding
         ? (axisRange.max as number)
         : logScale && isFinite(ratio) && ratio > 0
         ? (axisRange.max as number) *

--- a/src/utils/logscale-dtick.ts
+++ b/src/utils/logscale-dtick.ts
@@ -17,10 +17,8 @@ export function logScaleDtick(range: NumberOrDateRange | undefined): number {
     isNumber(range.min)
   ) {
     const ratio = range.max / range.min;
-    console.log(ratio);
     if (ratio < 10) {
       if (ratio >= 2) return Math.log10(2);
-
       // for extreme low-range cases like body temperature
       // unfortunately does not give integer tick marks
       return Math.log10(1.1);

--- a/src/utils/logscale-dtick.ts
+++ b/src/utils/logscale-dtick.ts
@@ -10,7 +10,6 @@ import { isNumber } from '../types/guards';
  *
  */
 export function logScaleDtick(range: NumberOrDateRange | undefined): number {
-  console.log(`incoming range ${range?.min} to ${range?.max}`);
   if (
     range != null &&
     range.min > 0 &&

--- a/src/utils/logscale-dtick.ts
+++ b/src/utils/logscale-dtick.ts
@@ -1,0 +1,31 @@
+import { NumberOrDateRange } from '../types/general';
+import { isNumber } from '../types/guards';
+
+/**
+ * Given an axis range, this will usually a value of 1 to be used in Plotly's layout.{x,y}axis.dtick,
+ * which indicates 10-fold tickmark spacing (it's calculated as 10**dtick)
+ *
+ * However, if the ratio between range.max/range.min is less than 10, we need to use a smaller spacing
+ * so that we get some tick marks.
+ *
+ */
+export function logScaleDtick(range: NumberOrDateRange | undefined): number {
+  console.log(`incoming range ${range?.min} to ${range?.max}`);
+  if (
+    range != null &&
+    range.min > 0 &&
+    isNumber(range.max) &&
+    isNumber(range.min)
+  ) {
+    const ratio = range.max / range.min;
+    console.log(ratio);
+    if (ratio < 10) {
+      if (ratio >= 2) return Math.log10(2);
+
+      // for extreme low-range cases like body temperature
+      // unfortunately does not give integer tick marks
+      return Math.log10(1.1);
+    }
+  }
+  return 1;
+}

--- a/src/utils/truncation-layout-shapes.ts
+++ b/src/utils/truncation-layout-shapes.ts
@@ -69,28 +69,6 @@ export function truncationLayoutShapes(
     ];
   }
 
-  // dependent axis max
-  if (axisTruncationConfig?.dependentAxis?.max) {
-    truncationLayoutShapes = [
-      ...truncationLayoutShapes,
-      {
-        type: 'rect',
-        line: {
-          width: 0,
-          dash: 'dash',
-        },
-        fillcolor: filledColor,
-        opacity: 1,
-        xref: orientation === 'vertical' ? 'paper' : 'x',
-        yref: orientation === 'vertical' ? 'y' : 'paper',
-        x0: orientation === 'vertical' ? 0 : standardDependentAxisRange?.max,
-        x1: orientation === 'vertical' ? 1 : extendedDependentAxisRange?.max,
-        y0: orientation === 'vertical' ? standardDependentAxisRange?.max : 0,
-        y1: orientation === 'vertical' ? extendedDependentAxisRange?.max : 1,
-      },
-    ];
-  }
-
   // dependent axis min
   if (axisTruncationConfig?.dependentAxis?.min) {
     truncationLayoutShapes = [
@@ -109,6 +87,28 @@ export function truncationLayoutShapes(
         x1: orientation === 'vertical' ? 1 : extendedDependentAxisRange?.min,
         y0: orientation === 'vertical' ? standardDependentAxisRange?.min : 0,
         y1: orientation === 'vertical' ? extendedDependentAxisRange?.min : 1,
+      },
+    ];
+  }
+
+  // dependent axis max
+  if (axisTruncationConfig?.dependentAxis?.max) {
+    truncationLayoutShapes = [
+      ...truncationLayoutShapes,
+      {
+        type: 'rect',
+        line: {
+          width: 0,
+          dash: 'dash',
+        },
+        fillcolor: filledColor,
+        opacity: 1,
+        xref: orientation === 'vertical' ? 'paper' : 'x',
+        yref: orientation === 'vertical' ? 'y' : 'paper',
+        x0: orientation === 'vertical' ? 0 : standardDependentAxisRange?.max,
+        x1: orientation === 'vertical' ? 1 : extendedDependentAxisRange?.max,
+        y0: orientation === 'vertical' ? standardDependentAxisRange?.max : 0,
+        y1: orientation === 'vertical' ? extendedDependentAxisRange?.max : 1,
       },
     ];
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4754,10 +4754,10 @@
   resolved "https://registry.yarnpkg.com/@veupathdb/browserslist-config/-/browserslist-config-1.0.0.tgz#90ca79640ffbb195a87d4d65cd4b2f92342f8b76"
   integrity sha512-qfKu1z9gaaHdMgRGaZBiayuIh92ishsf14lR+Rj61CJF131XWq3+5e2VyLyOdKsYJ1EreAxgyC/0upIBEzwQJw==
 
-"@veupathdb/coreui@^0.16.0":
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/@veupathdb/coreui/-/coreui-0.16.0.tgz#bb0e549d854f57a2dd784f1a3f8532d9685196ef"
-  integrity sha512-B6twkOliirk980Fau1a7r5F6yPMvKltkrqLMCnGHw6VRnw0TCtU+O334z1gznprPcn17rU0TiVPOB2SgJYTgjg==
+"@veupathdb/coreui@^0.17.8":
+  version "0.17.8"
+  resolved "https://registry.yarnpkg.com/@veupathdb/coreui/-/coreui-0.17.8.tgz#f138feb8a7dcec8870656aa63caf547346ed060f"
+  integrity sha512-rO19T05tA9V3xmuKW3a1/KvXCG6mlx7Baiwz/yBCGON5Qw2268Ow7JqFLVjKfYUqG5QJiJjumyOtxSS9PZPG0w==
   dependencies:
     "@react-hook/size" "^2.1.2"
     lodash "^4.17.21"


### PR DESCRIPTION
This is branched out from https://github.com/VEuPathDB/web-components/pull/363 to address two things for scatter and line plots:

a) set log scale range correctly
b) truncation

This is related to the web-eda PR, https://github.com/VEuPathDB/web-eda/pull/1241

To reviewers, @bobular & @asizemore: 
As mentioned above, I have branched out from https://github.com/VEuPathDB/web-components/pull/363 to address the two tasks. I have separated them because this one would have taken some time while you were reviewing the previous PR. 

Now, you can review this PR instead of https://github.com/VEuPathDB/web-eda/pull/1241.