### PR TITLE
testing sharedPlotCreation for react-leaflet v3

### DIFF
--- a/src/map/MapVEuMap.tsx
+++ b/src/map/MapVEuMap.tsx
@@ -9,6 +9,7 @@ import React, {
   useImperativeHandle,
   forwardRef,
   useCallback,
+  useRef,
 } from 'react';
 import {
   BoundsViewport,
@@ -33,7 +34,7 @@ import { PlotRef } from '../types/plots';
 import { ToImgopts } from 'plotly.js';
 import Spinner from '../components/Spinner';
 import NoDataOverlay from '../components/NoDataOverlay';
-import { LatLngBounds } from 'leaflet';
+import { LatLngBounds, Map } from 'leaflet';
 import domToImage from 'dom-to-image';
 //DKDK
 import { makeSharedPromise } from '../utils/promise-utils';
@@ -197,20 +198,23 @@ function MapVEuMap(props: MapVEuMapProps, ref: Ref<PlotRef>) {
   // Whether the user is currently dragging the map
   const [isDragging, setIsDragging] = useState<boolean>(false);
 
-  // set useSatate to handle map instance instead of useRef using 'whenCreated' prop at MapContainer
-  const [mapRef, setMapRef] = useState<any>(null);
+  // use a ref to avoid unneeded renders
+  const mapRef = useRef<Map>();
 
   /**DKDK This is used to ensure toImage is called after the plot has been created */
   const sharedPlotCreation = useMemo(
-    () => makeSharedPromise(async () => {}),
+    () => makeSharedPromise(() => Promise.resolve()),
     []
   );
 
   //DKDK
-  const onInitialized = useCallback(() => {
-    // setMapRef();
-    sharedPlotCreation.run();
-  }, [sharedPlotCreation.run]);
+  const onCreated = useCallback(
+    (map: Map) => {
+      mapRef.current = map;
+      sharedPlotCreation.run();
+    },
+    [sharedPlotCreation.run]
+  );
 
   console.log('map outside =', mapRef);
 
@@ -220,19 +224,12 @@ function MapVEuMap(props: MapVEuMapProps, ref: Ref<PlotRef>) {
       // Set the ref's toImage function that will be called in web-eda
       toImage: async (imageOpts: ToImgopts) => {
         // Wait to allow map to finish rendering
-        // await new Promise((resolve) => setTimeout(resolve, 1000));
-        //DKDK
-        try {
-          await sharedPlotCreation.promise;
-          // if (!mapRef) throw new Error('Map not ready');
-          console.log('map inside =', mapRef);
-          return await domToImage.toPng(mapRef.getContainer(), imageOpts);
-          // return await domToImage.toPng(mapRef._container, imageOpts);
-        } catch (error) {
-          // throw new Error('Map not ready');
-          throw new Error('Could not create image for plot');
-          // console.error('Could not create image for plot:', error);
-        }
+        await new Promise((res) => setTimeout(res, 1000));
+        await sharedPlotCreation.promise;
+
+        if (!mapRef.current) throw new Error('Map not ready');
+        console.log('map inside =', mapRef);
+        return domToImage.toPng(mapRef.current.getContainer(), imageOpts);
       },
     }),
     [domToImage, mapRef]
@@ -252,14 +249,7 @@ function MapVEuMap(props: MapVEuMapProps, ref: Ref<PlotRef>) {
       className={mouseMode === 'magnification' ? 'cursor-zoom-in' : ''}
       minZoom={1}
       worldCopyJump={false}
-      // ondragstart and ondragend work?
-      ondragstart={() => setIsDragging(true)}
-      ondragend={() => setIsDragging(false)}
-      // DKDK
-      // this prop is used to use map instance
-      whenCreated={setMapRef}
-      //DKDK
-      whenReady={onInitialized}
+      whenCreated={onCreated}
     >
       <TileLayer
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"

--- a/src/map/MapVEuMap.tsx
+++ b/src/map/MapVEuMap.tsx
@@ -36,7 +36,6 @@ import Spinner from '../components/Spinner';
 import NoDataOverlay from '../components/NoDataOverlay';
 import { LatLngBounds, Map } from 'leaflet';
 import domToImage from 'dom-to-image';
-//DKDK
 import { makeSharedPromise } from '../utils/promise-utils';
 
 // define Viewport type
@@ -201,13 +200,12 @@ function MapVEuMap(props: MapVEuMapProps, ref: Ref<PlotRef>) {
   // use a ref to avoid unneeded renders
   const mapRef = useRef<Map>();
 
-  /**DKDK This is used to ensure toImage is called after the plot has been created */
+  // This is used to ensure toImage is called after the plot has been created
   const sharedPlotCreation = useMemo(
     () => makeSharedPromise(() => Promise.resolve()),
     []
   );
 
-  //DKDK
   const onCreated = useCallback(
     (map: Map) => {
       mapRef.current = map;
@@ -215,8 +213,6 @@ function MapVEuMap(props: MapVEuMapProps, ref: Ref<PlotRef>) {
     },
     [sharedPlotCreation.run]
   );
-
-  console.log('map outside =', mapRef);
 
   useImperativeHandle<PlotRef, PlotRef>(
     ref,
@@ -228,7 +224,6 @@ function MapVEuMap(props: MapVEuMapProps, ref: Ref<PlotRef>) {
         await sharedPlotCreation.promise;
 
         if (!mapRef.current) throw new Error('Map not ready');
-        console.log('map inside =', mapRef);
         return domToImage.toPng(mapRef.current.getContainer(), imageOpts);
       },
     }),

--- a/src/map/MapVEuMap.tsx
+++ b/src/map/MapVEuMap.tsx
@@ -257,7 +257,7 @@ function MapVEuMap(props: MapVEuMapProps, ref: Ref<PlotRef>) {
       // ondragstart and ondragend work?
       ondragstart={() => setIsDragging(true)}
       ondragend={() => setIsDragging(false)}
-      DKDK
+      // DKDK
       // this prop is used to use map instance
       whenCreated={setMapRef}
       //DKDK

--- a/src/stories/Map.stories.tsx
+++ b/src/stories/Map.stories.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useState, useCallback } from 'react';
+import { ReactElement, useState, useCallback, useRef, useEffect } from 'react';
 import { Story, Meta } from '@storybook/react/types-6-0';
 // import { action } from '@storybook/addon-actions';
 import { BoundsViewport } from '../map/Types';
@@ -20,6 +20,7 @@ import MapVEuLegendSampleList, {
 
 import geohashAnimation from '../map/animation_functions/geohash';
 import { MouseMode } from '../map/MouseTools';
+import { PlotRef } from '../../lib/types/plots';
 
 export default {
   title: 'Map/General',
@@ -222,8 +223,8 @@ export const Windowed: Story<MapVEuMapProps> = (args) => {
         dropdownHref={dropdownHref}
         dropdownItemText={dropdownItemText}
         legendInfoNumberText={legendInfoNumberText}
-      />
-    </>
+        />
+        </>
   );
 };
 
@@ -237,4 +238,47 @@ Windowed.args = {
   },
   showGrid: true,
   showMouseToolbar: true,
+};
+
+export const ScreenshotOnLoad: Story<MapVEuMapProps> = function ScreenhotOnLoad(
+  args
+) {
+  const mapRef = useRef<PlotRef>(null);
+  const [image, setImage] = useState('');
+  useEffect(() => {
+    // We're converting the base64 encoding of the image to an object url
+    // because the size of the base64 encoding causes "too much recursion".
+    mapRef.current
+      ?.toImage({
+        height: args.height as number,
+        width: args.width as number,
+        format: 'png',
+      })
+      .then(fetch)
+      .then((res) => res.blob())
+      .then(URL.createObjectURL)
+      .then(setImage);
+  }, []);
+
+  return (
+    <div style={{ display: 'flex' }}>
+      <MapVEuMap
+        {...args}
+        ref={mapRef}
+        animation={defaultAnimation}
+        zoomLevelToGeohashLevel={leafletZoomLevelToGeohashLevel}
+      />
+      <img src={image} />
+    </div>
+  );
+};
+
+ScreenshotOnLoad.args = {
+  height: 500,
+  width: 700,
+  showGrid: true,
+  showMouseToolbar: true,
+  markers: [],
+  viewport: { center: [13, 16], zoom: 4 },
+  onBoundsChanged: () => {},
 };

--- a/src/stories/Map.stories.tsx
+++ b/src/stories/Map.stories.tsx
@@ -20,7 +20,7 @@ import MapVEuLegendSampleList, {
 
 import geohashAnimation from '../map/animation_functions/geohash';
 import { MouseMode } from '../map/MouseTools';
-import { PlotRef } from '../../lib/types/plots';
+import { PlotRef } from '../types/plots';
 
 export default {
   title: 'Map/General',
@@ -223,8 +223,8 @@ export const Windowed: Story<MapVEuMapProps> = (args) => {
         dropdownHref={dropdownHref}
         dropdownItemText={dropdownItemText}
         legendInfoNumberText={legendInfoNumberText}
-        />
-        </>
+      />
+    </>
   );
 };
 


### PR DESCRIPTION
This draft PR is for @dmfalke 😄 (branched out from react-leaflet-v3-ref (https://github.com/VEuPathDB/web-components/pull/347), testing sharedPlotCreation used in PlotlyPlot component, but did not work for me.

I know that Dave changed package.json to allow react-leaflet v3 but somehow it did not work for me. Thus I am still using npm-pack-here to work with MapViz at web-eda.

Note that I left console.logs to check the change of mapRef (map ref). From my observation, even without implementing sharedPlotCreation, mapRef inside useImperativeHandle does not change for initial map (mapRef inside = null) load even if outside mapRef is changed before using useImperativeHandle. 