### PR TITLE
addressing SVG log scale

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/components",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "license": "Apache-2.0",
   "description": "React Components for VEuPathDB Websites",
   "repository": {

--- a/src/map/ChartMarker.tsx
+++ b/src/map/ChartMarker.tsx
@@ -90,12 +90,12 @@ export default function ChartMarker(props: ChartMarkerProps) {
         });
 
   // find local min/max (one marker)
-  const localMinValue: number = Math.min(
-    ...fullStat.map((o) => o.value).filter((a) => a > 0)
-  ); // max of fullStat.value per marker icon
-  const localMaxValue: number = Math.max(
-    ...fullStat.map((o) => o.value).filter((a) => a > 0)
-  ); // max of fullStat.value per marker icon
+  const localMinMaxPosRange: any = props.dependentAxisRange
+    ? props.dependentAxisRange
+    : {
+        min: Math.min(...fullStat.map((o) => o.value).filter((a) => a > 0)),
+        max: Math.max(...fullStat.map((o) => o.value).filter((a) => a > 0)),
+      };
 
   const roundX = 10; // round corner in pixel: 0 = right angle
   const roundY = 10; // round corner in pixel: 0 = right angle
@@ -153,14 +153,14 @@ export default function ChartMarker(props: ChartMarkerProps) {
               props.dependentAxisRange.max / props.dependentAxisRange.min
             )) *
           (size - 2 * marginY)
-        : (Math.log10(el.value / localMinValue) /
-            Math.log10(localMaxValue / localMinValue)) *
+        : (Math.log10(el.value / localMinMaxPosRange.min) /
+            Math.log10(localMinMaxPosRange.max / localMinMaxPosRange.min)) *
           (size - 2 * marginY)
       : props.dependentAxisRange // no log scale
       ? ((el.value - props.dependentAxisRange.min) /
           (props.dependentAxisRange.max - props.dependentAxisRange.min)) *
         (size - 2 * marginY) // bar height: used 2*marginY to have margins at both top and bottom
-      : (el.value / localMaxValue) * (size - 2 * marginY); // bar height: used 2*marginY to have margins at both top and bottom
+      : (el.value / localMinMaxPosRange.max) * (size - 2 * marginY); // bar height: used 2*marginY to have margins at both top and bottom
 
     startingY = size - marginY - barHeight + borderWidth; // y in <react> tag: note that (0,0) is top left of the marker icon
     // making the last bar, noData

--- a/src/map/ChartMarker.tsx
+++ b/src/map/ChartMarker.tsx
@@ -89,11 +89,13 @@ export default function ChartMarker(props: ChartMarkerProps) {
           maximumFractionDigits: 0,
         });
 
-  // find local min/max (one marker)
-  const localMinMaxPosRange: any = props.dependentAxisRange
+  // determine min/max (one marker)
+  const minMaxPosRange: NumberRange = props.dependentAxisRange
     ? props.dependentAxisRange
     : {
-        min: Math.min(...fullStat.map((o) => o.value).filter((a) => a > 0)),
+        min: props.dependentAxisLogScale
+          ? Math.min(...fullStat.map((o) => o.value).filter((a) => a > 0))
+          : 0,
         max: Math.max(...fullStat.map((o) => o.value).filter((a) => a > 0)),
       };
 
@@ -144,23 +146,15 @@ export default function ChartMarker(props: ChartMarkerProps) {
     barWidth = (xSize - 2 * marginX) / count; // bar width
     startingX = marginX + borderWidth + barWidth * index; // x in <react> tag: note that (0,0) is top left of the marker icon
     barHeight = props.dependentAxisLogScale // log scale
-      ? el.value === 0 || el.value < 0
+      ? el.value <= 0
         ? 0
         : // if dependentAxisRange != null, plot with global max
-        props.dependentAxisRange
-        ? (Math.log10(el.value / props.dependentAxisRange.min) /
-            Math.log10(
-              props.dependentAxisRange.max / props.dependentAxisRange.min
-            )) *
+          (Math.log10(el.value / minMaxPosRange.min) /
+            Math.log10(minMaxPosRange.max / minMaxPosRange.min)) *
           (size - 2 * marginY)
-        : (Math.log10(el.value / localMinMaxPosRange.min) /
-            Math.log10(localMinMaxPosRange.max / localMinMaxPosRange.min)) *
-          (size - 2 * marginY)
-      : props.dependentAxisRange // no log scale
-      ? ((el.value - props.dependentAxisRange.min) /
-          (props.dependentAxisRange.max - props.dependentAxisRange.min)) *
-        (size - 2 * marginY) // bar height: used 2*marginY to have margins at both top and bottom
-      : (el.value / localMinMaxPosRange.max) * (size - 2 * marginY); // bar height: used 2*marginY to have margins at both top and bottom
+      : ((el.value - minMaxPosRange.min) /
+          (minMaxPosRange.max - minMaxPosRange.min)) *
+        (size - 2 * marginY); // bar height: used 2*marginY to have margins at both top and bottom
 
     startingY = size - marginY - barHeight + borderWidth; // y in <react> tag: note that (0,0) is top left of the marker icon
     // making the last bar, noData


### PR DESCRIPTION
This draft PR is branched out from https://github.com/VEuPathDB/web-components/pull/371 as this needs map's log scale functionality

This is a temporary solution, just minimizing gap between small and large (using mouse tool) charts: Please see this comment for more detailed info: https://github.com/VEuPathDB/web-components/issues/380#issuecomment-1203128901.