### PR TITLE
power format of axis label

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/components",
-  "version": "0.17.4",
+  "version": "0.17.5",
   "license": "Apache-2.0",
   "description": "React Components for VEuPathDB Websites",
   "repository": {

--- a/src/plots/Barplot.tsx
+++ b/src/plots/Barplot.tsx
@@ -203,7 +203,6 @@ const Barplot = makePlotlyPlotComponent(
 
     const dependentAxisLayout: Layout['yaxis'] | Layout['xaxis'] = {
       automargin: true,
-      tickformat: dependentAxisLogScale ? ',.1r' : undefined, // comma-separated thousands, rounded to 1 significant digit
       hoverformat: dependentAxisLogScale
         ? dataLooksFractional
           ? ',.4f'
@@ -229,6 +228,8 @@ const Barplot = makePlotlyPlotComponent(
         ? logScaleDtick(extendedDependentAxisRange)
         : undefined,
       showticklabels: showDependentAxisTickLabel,
+      showexponent: 'all',
+      exponentformat: 'power',
     };
 
     const layout: Partial<Layout> = {

--- a/src/plots/Barplot.tsx
+++ b/src/plots/Barplot.tsx
@@ -23,7 +23,7 @@ import { NumberRange } from '../types/general';
 // import truncation util functions
 import { extendAxisRangeForTruncations } from '../utils/extended-axis-range-truncations';
 import { truncationLayoutShapes } from '../utils/truncation-layout-shapes';
-import { logScaleDtick } from '../utils/logscale-dtick';
+import { tickSettings } from '../utils/tick-settings';
 
 // in this example, the main variable is 'country'
 export interface BarplotProps
@@ -224,12 +224,12 @@ const Barplot = makePlotlyPlotComponent(
               : val
           )
         : [0, 10],
-      dtick: dependentAxisLogScale
-        ? logScaleDtick(extendedDependentAxisRange)
-        : undefined,
       showticklabels: showDependentAxisTickLabel,
-      showexponent: 'all',
-      exponentformat: 'power',
+      ...tickSettings(
+        dependentAxisLogScale,
+        extendedDependentAxisRange,
+        'number'
+      ),
     };
 
     const layout: Partial<Layout> = {

--- a/src/plots/Histogram.tsx
+++ b/src/plots/Histogram.tsx
@@ -34,7 +34,7 @@ import { Layout, Shape } from 'plotly.js';
 // import truncation util functions
 import { extendAxisRangeForTruncations } from '../utils/extended-axis-range-truncations';
 import { truncationLayoutShapes } from '../utils/truncation-layout-shapes';
-import { logScaleDtick } from '../utils/logscale-dtick';
+import { tickSettings } from '../utils/tick-settings';
 
 // bin middles needed for highlighting
 interface BinSummary {
@@ -473,16 +473,15 @@ const Histogram = makePlotlyPlotComponent(
               : val
           )
         : [0, 10],
-      dtick: dependentAxisLogScale
-        ? logScaleDtick(extendedDependentAxisRange)
-        : undefined,
       tickfont: data.series.length ? {} : { color: 'transparent' },
       showline: !axisTruncationConfig?.independentAxis?.min,
       linecolor: '#dddddd',
       zeroline: false,
-      showexponent: 'all',
-      exponentformat:
-        data?.binWidthSlider?.valueType === 'date' ? 'none' : 'power',
+      ...tickSettings(
+        dependentAxisLogScale,
+        extendedDependentAxisRange,
+        data?.binWidthSlider?.valueType
+      ),
     };
 
     return {

--- a/src/plots/Histogram.tsx
+++ b/src/plots/Histogram.tsx
@@ -450,7 +450,6 @@ const Histogram = makePlotlyPlotComponent(
 
     const dependentAxisLayout: Layout['yaxis'] | Layout['xaxis'] = {
       type: dependentAxisLogScale ? 'log' : 'linear',
-      tickformat: dependentAxisLogScale ? ',.1r' : undefined, // comma-separated thousands, rounded to 1 significant digit
       hoverformat: dependentAxisLogScale
         ? dataLooksFractional
           ? ',.4f'
@@ -481,6 +480,9 @@ const Histogram = makePlotlyPlotComponent(
       showline: !axisTruncationConfig?.independentAxis?.min,
       linecolor: '#dddddd',
       zeroline: false,
+      showexponent: 'all',
+      exponentformat:
+        data?.binWidthSlider?.valueType === 'date' ? 'none' : 'power',
     };
 
     return {

--- a/src/plots/LinePlot.tsx
+++ b/src/plots/LinePlot.tsx
@@ -19,6 +19,7 @@ import {
 import { extendAxisRangeForTruncations } from '../utils/extended-axis-range-truncations';
 import { truncationLayoutShapes } from '../utils/truncation-layout-shapes';
 import { logScaleDtick } from '../utils/logscale-dtick';
+import { tickSettings } from '../utils/tick-settings';
 
 // is it possible to have this interface extend ScatterPlotProps?
 // or would we need some abstract layer, w scatter and line both as equal children below it?
@@ -148,11 +149,11 @@ const LinePlot = makePlotlyPlotComponent('LinePlot', (props: LinePlotProps) => {
           ? 'log'
           : undefined,
       tickfont: data.series.length ? {} : { color: 'transparent' },
-      dtick: independentAxisLogScale
-        ? logScaleDtick(extendedIndependentAxisRange)
-        : undefined,
-      showexponent: 'all',
-      exponentformat: independentValueType === 'date' ? 'none' : 'power',
+      ...tickSettings(
+        independentAxisLogScale,
+        extendedIndependentAxisRange,
+        independentValueType
+      ),
     },
     yaxis: {
       title: dependentAxisLabel,
@@ -178,12 +179,11 @@ const LinePlot = makePlotlyPlotComponent('LinePlot', (props: LinePlotProps) => {
           ? 'log'
           : undefined,
       tickfont: data.series.length ? {} : { color: 'transparent' },
-      //DKDK this dtick is conflicted with power format of axis tick label
-      // dtick: dependentAxisLogScale
-      //   ? logScaleDtick(extendedDependentAxisRange)
-      //   : undefined,
-      showexponent: 'all',
-      exponentformat: dependentValueType === 'date' ? 'none' : 'power',
+      ...tickSettings(
+        dependentAxisLogScale,
+        extendedDependentAxisRange,
+        dependentValueType
+      ),
     },
     // axis range control: add truncatedAxisHighlighting for layout.shapes
     shapes: truncatedAxisHighlighting,

--- a/src/plots/LinePlot.tsx
+++ b/src/plots/LinePlot.tsx
@@ -18,7 +18,6 @@ import {
 // import truncation util functions
 import { extendAxisRangeForTruncations } from '../utils/extended-axis-range-truncations';
 import { truncationLayoutShapes } from '../utils/truncation-layout-shapes';
-import { logScaleDtick } from '../utils/logscale-dtick';
 import { tickSettings } from '../utils/tick-settings';
 
 // is it possible to have this interface extend ScatterPlotProps?

--- a/src/plots/LinePlot.tsx
+++ b/src/plots/LinePlot.tsx
@@ -151,6 +151,8 @@ const LinePlot = makePlotlyPlotComponent('LinePlot', (props: LinePlotProps) => {
       dtick: independentAxisLogScale
         ? logScaleDtick(extendedIndependentAxisRange)
         : undefined,
+      showexponent: 'all',
+      exponentformat: independentValueType === 'date' ? 'none' : 'power',
     },
     yaxis: {
       title: dependentAxisLabel,
@@ -179,6 +181,8 @@ const LinePlot = makePlotlyPlotComponent('LinePlot', (props: LinePlotProps) => {
       dtick: dependentAxisLogScale
         ? logScaleDtick(extendedDependentAxisRange)
         : undefined,
+      showexponent: 'all',
+      exponentformat: dependentValueType === 'date' ? 'none' : 'power',
     },
     // axis range control: add truncatedAxisHighlighting for layout.shapes
     shapes: truncatedAxisHighlighting,

--- a/src/plots/LinePlot.tsx
+++ b/src/plots/LinePlot.tsx
@@ -178,9 +178,10 @@ const LinePlot = makePlotlyPlotComponent('LinePlot', (props: LinePlotProps) => {
           ? 'log'
           : undefined,
       tickfont: data.series.length ? {} : { color: 'transparent' },
-      dtick: dependentAxisLogScale
-        ? logScaleDtick(extendedDependentAxisRange)
-        : undefined,
+      //DKDK this dtick is conflicted with power format of axis tick label
+      // dtick: dependentAxisLogScale
+      //   ? logScaleDtick(extendedDependentAxisRange)
+      //   : undefined,
       showexponent: 'all',
       exponentformat: dependentValueType === 'date' ? 'none' : 'power',
     },

--- a/src/plots/ScatterPlot.tsx
+++ b/src/plots/ScatterPlot.tsx
@@ -12,7 +12,7 @@ import {
   DependentAxisLogScaleDefault,
 } from '../types/plots';
 // add Shape for truncation
-import { Layout, Shape } from 'plotly.js';
+import { Layout, Shape, Axis, LayoutAxis } from 'plotly.js';
 import { NumberOrDateRange } from '../types/general';
 
 // import truncation util functions
@@ -150,6 +150,10 @@ const ScatterPlot = makePlotlyPlotComponent(
         dtick: independentAxisLogScale
           ? logScaleDtick(extendedIndependentAxisRange)
           : undefined,
+        showexponent: 'all',
+        exponentformat: independentValueType === 'date' ? 'none' : 'power',
+        // type minexponent is not defined at @types/plotly.js but 3 is default so not used here
+        // minexponent: 3,
       },
       yaxis: {
         title: dependentAxisLabel,
@@ -179,6 +183,10 @@ const ScatterPlot = makePlotlyPlotComponent(
         dtick: dependentAxisLogScale
           ? logScaleDtick(extendedDependentAxisRange)
           : undefined,
+        showexponent: 'all',
+        exponentformat: dependentValueType === 'date' ? 'none' : 'power',
+        // type minexponent is not defined at @types/plotly.js but 3 is default so not used here
+        // minexponent: 3,
       },
       // add truncatedAxisHighlighting for layout.shapes
       shapes: truncatedAxisHighlighting,

--- a/src/plots/ScatterPlot.tsx
+++ b/src/plots/ScatterPlot.tsx
@@ -19,6 +19,7 @@ import { NumberOrDateRange } from '../types/general';
 import { extendAxisRangeForTruncations } from '../utils/extended-axis-range-truncations';
 import { truncationLayoutShapes } from '../utils/truncation-layout-shapes';
 import { logScaleDtick } from '../utils/logscale-dtick';
+import { tickSettings } from '../utils/tick-settings';
 
 export interface ScatterPlotProps
   extends PlotProps<ScatterPlotData>,
@@ -147,13 +148,11 @@ const ScatterPlot = makePlotlyPlotComponent(
             ? 'log'
             : undefined,
         tickfont: data.series.length ? {} : { color: 'transparent' },
-        dtick: independentAxisLogScale
-          ? logScaleDtick(extendedIndependentAxisRange)
-          : undefined,
-        showexponent: 'all',
-        exponentformat: independentValueType === 'date' ? 'none' : 'power',
-        // type minexponent is not defined at @types/plotly.js but 3 is default so not used here
-        // minexponent: 3,
+        ...tickSettings(
+          independentAxisLogScale,
+          extendedIndependentAxisRange,
+          independentValueType
+        ),
       },
       yaxis: {
         title: dependentAxisLabel,
@@ -180,13 +179,11 @@ const ScatterPlot = makePlotlyPlotComponent(
             ? 'log'
             : undefined,
         tickfont: data.series.length ? {} : { color: 'transparent' },
-        dtick: dependentAxisLogScale
-          ? logScaleDtick(extendedDependentAxisRange)
-          : undefined,
-        showexponent: 'all',
-        exponentformat: dependentValueType === 'date' ? 'none' : 'power',
-        // type minexponent is not defined at @types/plotly.js but 3 is default so not used here
-        // minexponent: 3,
+        ...tickSettings(
+          dependentAxisLogScale,
+          extendedDependentAxisRange,
+          dependentValueType
+        ),
       },
       // add truncatedAxisHighlighting for layout.shapes
       shapes: truncatedAxisHighlighting,

--- a/src/stories/plots/LinePlot.stories.tsx
+++ b/src/stories/plots/LinePlot.stories.tsx
@@ -1,7 +1,16 @@
+import React, { useEffect, useState } from 'react';
 import { Story, Meta } from '@storybook/react/types-6-0';
 import LinePlot, { LinePlotProps } from '../../plots/LinePlot';
 import { FacetedData, LinePlotData } from '../../types/plots';
 import FacetedLinePlot from '../../plots/facetedPlots/FacetedLinePlot';
+import AxisRangeControl from '../../components/plotControls/AxisRangeControl';
+import {
+  NumberRange,
+  NumberOrDateRange,
+  NumberOrTimeDelta,
+  TimeDelta,
+} from '../../types/general';
+import Switch from '../../components/widgets/Switch';
 
 export default {
   title: 'Plots/LinePlot',
@@ -152,5 +161,71 @@ Faceted.args = {
       height: '100%',
       margin: 'auto',
     },
+  },
+};
+
+//DKDK testing log scale
+const dataSetLog = {
+  series: [
+    {
+      x: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      y: [33, 36, 35, 37, 35, 34, 35, 36, 33, 37, 35],
+      name: 'data',
+    },
+  ],
+};
+
+const TemplateWithSelectedRangeControls: Story<Omit<LinePlotProps, 'data'>> = (
+  args
+) => {
+  const [dependentAxisRange, setDependentAxisRange] = useState<
+    NumberOrDateRange | undefined
+  >({ min: 1, max: 80 });
+  const [dependentAxisLogScale, setDependentAxisLogScale] = useState<
+    boolean | undefined
+  >(false);
+
+  const handleDependentAxisRangeChange = async (
+    newRange?: NumberOrDateRange
+  ) => {
+    setDependentAxisRange(newRange);
+  };
+
+  const onDependentAxisLogScaleChange = async (value?: boolean) => {
+    setDependentAxisLogScale(value);
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column' }}>
+      <LinePlot
+        data={dataSetLog}
+        {...args}
+        dependentAxisRange={dependentAxisRange}
+        dependentAxisLogScale={dependentAxisLogScale}
+      />
+      <Switch
+        label="Log scale (will exclude values &le; 0):"
+        state={dependentAxisLogScale}
+        onStateChange={(newValue: boolean) => {
+          onDependentAxisLogScaleChange(newValue);
+        }}
+        containerStyles={{ marginLeft: '5em' }}
+      />
+      <div style={{ height: 25 }} />
+      <AxisRangeControl
+        label="Y-axis range control"
+        range={dependentAxisRange}
+        onRangeChange={handleDependentAxisRangeChange}
+        containerStyles={{ marginLeft: '5em' }}
+      />
+    </div>
+  );
+};
+
+export const LogScale = TemplateWithSelectedRangeControls.bind({});
+LogScale.args = {
+  containerStyles: {
+    height: '450px',
+    width: '750px',
   },
 };

--- a/src/utils/tick-settings.ts
+++ b/src/utils/tick-settings.ts
@@ -1,0 +1,31 @@
+import { NumberOrDateRange } from '../types/general';
+import { logScaleDtick } from './logscale-dtick';
+
+interface tickSettingsType {
+  dtick: number | undefined;
+  showexponent: 'all' | 'none' | 'first' | 'last' | undefined;
+  exponentformat: 'none' | 'e' | 'E' | 'power' | 'SI' | 'B';
+  minexponent?: number;
+}
+
+export function tickSettings(
+  logScale: boolean,
+  range: NumberOrDateRange | undefined,
+  valueType: 'string' | 'number' | 'date' | 'longitude' | 'category' | undefined
+): tickSettingsType {
+  const axisDtick =
+    range != null && range.min != null && range.max != null && logScale
+      ? logScaleDtick(range)
+      : undefined;
+
+  return {
+    // tickformat is conflicted with exponentformat
+    dtick: axisDtick,
+    showexponent: 'all',
+    exponentformat:
+      valueType === 'date' || (axisDtick != null && axisDtick < 1)
+        ? 'none'
+        : 'power',
+    minexponent: 3,
+  };
+}


### PR DESCRIPTION
This will address https://github.com/VEuPathDB/web-eda/issues/1275

I have added the power format for Viz/axis who has log scale control such as Histogram Y-axis, barplot Y-axis, Scatterplot X and Y axes, and Lineplot X and Y axes.

For Histogram and Barplot, it was found that they had tickformat attribute that formats large number, so it is removed to show power format. 

Just for an information, Plotly.js actually supports minexponent attribute which controls the starting point of power format display. However, @types/plotly.js somehow do not have type for that. I saw that Danica wanted to show power format from five-figure (e.g., 10^4), which is the default value of minexponent (minexponent: 3), thus I did not consider typing for that: honestly, I could not find a way to extend type to support minexponent without changing @types/plotly.js either. 

Here is a screenshot with power format for the example case shown in the ticket.
![scatter-axis-power-format](https://user-images.githubusercontent.com/12802305/183991695-9e279e37-d72c-464f-a889-d82dd8cf7e7f.png)

