### PR TITLE
changing color for map continuous overlay

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/components",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "license": "Apache-2.0",
   "description": "React Components for VEuPathDB Websites",
   "repository": {

--- a/src/types/plots/addOns.ts
+++ b/src/types/plots/addOns.ts
@@ -145,18 +145,32 @@ export const ColorPaletteDark: string[] = [
 
 /** Sequential gradient colorscale. Useful for coloring based on a continuous variable that is always positive, for example. */
 /** Using oslo from https://www.fabiocrameri.ch/colourmaps/, copied from https://github.com/empet/scientific-colorscales/blob/master/scicolorscales.py */
+//DKDK test
+// export const SequentialGradientColorscale: string[] = [
+//   'rgb(0, 1, 0)',
+//   'rgb(11, 25, 39)',
+//   'rgb(17, 48, 77)',
+//   'rgb(27, 73, 117)',
+//   'rgb(46, 98, 160)',
+//   'rgb(78, 125, 199)',
+//   'rgb(111, 146, 202)',
+//   'rgb(144, 166, 201)',
+//   'rgb(176, 185, 200)',
+//   'rgb(215, 215, 216)',
+//   // 'rgb(255, 255, 255)',  Removing final, lightest, color for best visibility
+// ];
 export const SequentialGradientColorscale: string[] = [
-  'rgb(0, 1, 0)',
-  'rgb(11, 25, 39)',
-  'rgb(17, 48, 77)',
-  'rgb(27, 73, 117)',
-  'rgb(46, 98, 160)',
-  'rgb(78, 125, 199)',
-  'rgb(111, 146, 202)',
-  'rgb(144, 166, 201)',
-  'rgb(176, 185, 200)',
-  'rgb(215, 215, 216)',
   // 'rgb(255, 255, 255)',  Removing final, lightest, color for best visibility
+  'rgb(215, 215, 216)',
+  'rgb(176, 185, 200)',
+  'rgb(144, 166, 201)',
+  'rgb(111, 146, 202)',
+  'rgb(78, 125, 199)',
+  'rgb(46, 98, 160)',
+  'rgb(27, 73, 117)',
+  'rgb(17, 48, 77)',
+  'rgb(11, 25, 39)',
+  'rgb(0, 1, 0)',
 ];
 
 /** Diverging gradient colorscale. Useful for coloring a continuous variable that has values above and below a midpoint (usually 0) */

--- a/src/types/plots/addOns.ts
+++ b/src/types/plots/addOns.ts
@@ -145,20 +145,6 @@ export const ColorPaletteDark: string[] = [
 
 /** Sequential gradient colorscale. Useful for coloring based on a continuous variable that is always positive, for example. */
 /** Using oslo from https://www.fabiocrameri.ch/colourmaps/, copied from https://github.com/empet/scientific-colorscales/blob/master/scicolorscales.py */
-//DKDK test
-// export const SequentialGradientColorscale: string[] = [
-//   'rgb(0, 1, 0)',
-//   'rgb(11, 25, 39)',
-//   'rgb(17, 48, 77)',
-//   'rgb(27, 73, 117)',
-//   'rgb(46, 98, 160)',
-//   'rgb(78, 125, 199)',
-//   'rgb(111, 146, 202)',
-//   'rgb(144, 166, 201)',
-//   'rgb(176, 185, 200)',
-//   'rgb(215, 215, 216)',
-//   // 'rgb(255, 255, 255)',  Removing final, lightest, color for best visibility
-// ];
 export const SequentialGradientColorscale: string[] = [
   // 'rgb(255, 255, 255)',  Removing final, lightest, color for best visibility
   'rgb(215, 215, 216)',


### PR DESCRIPTION
This will possibly address https://github.com/VEuPathDB/web-eda/issues/1200. The easiest solution is to change the order of colors defined in SequentialGradientColorscale: alternatively, one may adjust array index at mapViz but in this PR, the former is used.

The change of color order at legend means that the bar colors should also be changed. Here is an example screenshot to show.
![map-continuous-color](https://user-images.githubusercontent.com/12802305/184008891-703e751a-d5a4-4ccf-b041-b4eb4e29ce3b.png)

(did not clean up the PR yet but will do it later)