### PR TITLE
Use existing default string for x-axis label in ChartMarker popover plot

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/components",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "license": "Apache-2.0",
   "description": "React Components for VEuPathDB Websites",
   "repository": {

--- a/src/map/ChartMarker.tsx
+++ b/src/map/ChartMarker.tsx
@@ -219,7 +219,6 @@ export default function ChartMarker(props: ChartMarkerProps) {
 
   // anim check duration exists or not
   let duration: number = props.duration ? props.duration : 300;
-  // let duration: number = (props.duration) ? 300 : 300
 
   const plotSize = 200;
   const marginSize = 5;
@@ -252,9 +251,7 @@ export default function ChartMarker(props: ChartMarkerProps) {
       displayLibraryControls={false}
       interactive={false}
       dependentAxisLabel=""
-      independentAxisLabel={
-        props.independentAxisLabel ?? `Total: ${sumValuesString}`
-      }
+      independentAxisLabel={`Total: ${sumValuesString}`}
       // dependentAxisRange is an object with {min, max} (NumberRange)
       dependentAxisRange={props.dependentAxisRange ?? undefined}
       showValues={true}

--- a/src/map/ChartMarker.tsx
+++ b/src/map/ChartMarker.tsx
@@ -25,8 +25,6 @@ interface ChartMarkerProps
   onClick?: (event: L.LeafletMouseEvent) => void | undefined;
   /** x-axis title for marker (defaults to sum of data[].value) */
   markerLabel?: string;
-  /** x-axis title for enlarged mouse-over marker (defaults to "Total: sum(data[].value)") */
-  independentAxisLabel?: string;
 }
 
 /**


### PR DESCRIPTION
Resolves #386 

The current implementation uses the `Total: <insert count>` string as a default value for the independent axis, like so:
```js
independentAxisLabel={
  props.independentAxisLabel ?? `Total: ${sumValuesString}`
}
```
I've removed the option to render the passed-in `props.independentAxisLabel` to only render the default string. The result is as shown.
![image](https://user-images.githubusercontent.com/69446567/185239086-fd7f9f9e-888d-4255-9f9c-49bd5c88209d.png)