### PR TITLE
RadioButtonGroup - new onSelectedOptionDisabled prop

### DIFF
--- a/src/components/widgets/RadioButtonGroup.tsx
+++ b/src/components/widgets/RadioButtonGroup.tsx
@@ -1,5 +1,5 @@
 // widget for radio button group
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useEffect } from 'react';
 import Radio from '@material-ui/core/Radio';
 import RadioGroup from '@material-ui/core/RadioGroup';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
@@ -19,6 +19,8 @@ export type RadioButtonGroupProps = {
   selectedOption: string;
   /** Action to take when an option is selected by the user. */
   onOptionSelected: (option: string) => void;
+  /** Action to take if the currently selected option has been disabled. */
+  onSelectedOptionDisabled?: (option: string) => void;
   /** Additional widget container styles. Optional. */
   containerStyles?: React.CSSProperties;
   /** location of radio button label: start: label & button; end: button & label */
@@ -46,6 +48,7 @@ export default function RadioButtonGroup({
   optionLabels,
   selectedOption,
   onOptionSelected,
+  onSelectedOptionDisabled,
   containerStyles = {},
   labelPlacement,
   minWidth,
@@ -56,6 +59,15 @@ export default function RadioButtonGroup({
 }: RadioButtonGroupProps) {
   // perhaps not using focused?
   // const [focused, setFocused] = useState(false);
+
+  useEffect(() => {
+    if (
+      onSelectedOptionDisabled != null &&
+      disabledList != null &&
+      disabledList.indexOf(selectedOption) >= 0
+    )
+      onSelectedOptionDisabled(selectedOption);
+  }, [selectedOption, disabledList, onSelectedOptionDisabled]);
 
   return (
     <div

--- a/src/stories/widgets/RadioButtonGroup.stories.tsx
+++ b/src/stories/widgets/RadioButtonGroup.stories.tsx
@@ -1,9 +1,11 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { Story, Meta } from '@storybook/react/types-6-0';
 
 import RadioButtonGroup, {
   RadioButtonGroupProps,
 } from '../../components/widgets/RadioButtonGroup';
+
+import Toggle from '@veupathdb/coreui/dist/components/widgets/Toggle';
 
 export default {
   title: 'Widgets/RadioButtonGroup',
@@ -39,4 +41,64 @@ export const Renamed = Template.bind({});
 Renamed.args = {
   ...Basic.args,
   optionLabels: ['Sideways', 'Upright'],
+};
+
+const DisabledBehaviourTemplate: Story<RadioButtonGroupProps> = (args) => {
+  const [selectedOption, setSelectedOption] = useState('default');
+  const [disabledOptions, setDisabledOptions] = useState<
+    Record<string, boolean>
+  >({});
+
+  const disablableOptions = args.options.filter(
+    (option) => option !== 'default'
+  );
+
+  const handleDisabledOptionChange = useCallback(
+    (option, newState) => {
+      // essential to make a copy of the record here, or react won't notice the state change
+      const newDisabledOptions = { ...disabledOptions, [option]: newState };
+      setDisabledOptions(newDisabledOptions);
+    },
+    [disabledOptions]
+  );
+
+  const onSelectedOptionDisabled = useCallback((_) => {
+    setSelectedOption('default');
+  }, []);
+
+  return (
+    <>
+      <div>
+        Selected value is{' '}
+        <span style={{ background: '#ccc', padding: 4 }}>{selectedOption}</span>
+      </div>
+      <RadioButtonGroup
+        {...args}
+        onOptionSelected={setSelectedOption}
+        disabledList={args.options.filter((option) => disabledOptions[option])}
+        onSelectedOptionDisabled={onSelectedOptionDisabled}
+        selectedOption={selectedOption}
+        containerStyles={{ ...args.containerStyles, margin: 25 }}
+      />
+      <span>Disable one or more options below</span>
+      {disablableOptions.map((option) => (
+        <div key={option} style={{ display: 'flex', flexDirection: 'row' }}>
+          <span style={{ width: '50px' }}>{option}</span>
+          <Toggle
+            value={!!disabledOptions[option]}
+            onChange={(newState) =>
+              handleDisabledOptionChange(option, newState)
+            }
+          />
+        </div>
+      ))}
+    </>
+  );
+};
+
+export const DisabledBehaviour = DisabledBehaviourTemplate.bind({});
+DisabledBehaviour.args = {
+  ...Basic.args,
+  options: ['default', 'one', 'two', 'three'],
+  label: 'Try disabling a selected option',
 };


### PR DESCRIPTION
Needed for work on FSM overlay variable constraints (Bob's PR pending)

New functionality and new story to demonstrate the situation where you have disabled a radio button input after it has already been selected. You can provide the `onSelectedOptionDisabled` callback to perform an action, such as setting the radio button state to 'default' as in the story. You could also show a snackbar! Mmm, snack bars...