### PR TITLE
legend gray out if filtered

### DIFF
--- a/src/components/plotControls/PlotLegend.tsx
+++ b/src/components/plotControls/PlotLegend.tsx
@@ -97,9 +97,10 @@ export default function PlotLegend({
                     alignItems: 'center',
                     fontSize: legendTextSize,
                     // gray out for filtered item
-                    color: checkedLegendItems?.includes(item.label)
-                      ? ''
-                      : '#999',
+                    color:
+                      checkedLegendItems?.includes(item.label) && item.hasData
+                        ? ''
+                        : '#999',
                     // add this for general usage (e.g., story)
                     margin: 0,
                   }}
@@ -135,11 +136,11 @@ export default function PlotLegend({
                           height: defaultMarkerSize,
                           width: defaultMarkerSize,
                           borderWidth: '0',
-                          backgroundColor: checkedLegendItems?.includes(
-                            item.label
-                          )
-                            ? item.markerColor
-                            : '#999',
+                          backgroundColor:
+                            checkedLegendItems?.includes(item.label) &&
+                            item.hasData
+                              ? item.markerColor
+                              : '#999',
                         }}
                       />
                     )}
@@ -151,16 +152,18 @@ export default function PlotLegend({
                           width: defaultMarkerSize,
                           borderWidth: '0.125em',
                           borderStyle: 'solid',
-                          borderColor: checkedLegendItems?.includes(item.label)
-                            ? item.markerColor
-                            : '#999',
-                          backgroundColor: checkedLegendItems?.includes(
-                            item.label
-                          )
-                            ? ColorMath.evaluate(
-                                item.markerColor + ' @a 50%'
-                              ).result.css()
-                            : '#999',
+                          borderColor:
+                            checkedLegendItems?.includes(item.label) &&
+                            item.hasData
+                              ? item.markerColor
+                              : '#999',
+                          backgroundColor:
+                            checkedLegendItems?.includes(item.label) &&
+                            item.hasData
+                              ? ColorMath.evaluate(
+                                  item.markerColor + ' @a 50%'
+                                ).result.css()
+                              : '#999',
                         }}
                       />
                     )}
@@ -175,11 +178,11 @@ export default function PlotLegend({
                             borderWidth: '0.15em',
                             borderStyle: 'solid',
                             borderRadius: '0.6em',
-                            borderColor: checkedLegendItems?.includes(
-                              item.label
-                            )
-                              ? item.markerColor
-                              : '#999',
+                            borderColor:
+                              checkedLegendItems?.includes(item.label) &&
+                              item.hasData
+                                ? item.markerColor
+                                : '#999',
                           }}
                         />
                       </div>
@@ -192,11 +195,11 @@ export default function PlotLegend({
                             height: '0.15em',
                             width: scatterMarkerSpace,
                             borderWidth: '0',
-                            backgroundColor: checkedLegendItems?.includes(
-                              item.label
-                            )
-                              ? item.markerColor
-                              : '#999',
+                            backgroundColor:
+                              checkedLegendItems?.includes(item.label) &&
+                              item.hasData
+                                ? item.markerColor
+                                : '#999',
                           }}
                         />
                       </div>
@@ -209,13 +212,13 @@ export default function PlotLegend({
                             height: '0.5em',
                             width: scatterMarkerSpace,
                             borderWidth: '0',
-                            backgroundColor: checkedLegendItems?.includes(
-                              item.label
-                            )
-                              ? ColorMath.evaluate(
-                                  item.markerColor + ' @a 30%'
-                                ).result.css()
-                              : '#999',
+                            backgroundColor:
+                              checkedLegendItems?.includes(item.label) &&
+                              item.hasData
+                                ? ColorMath.evaluate(
+                                    item.markerColor + ' @a 30%'
+                                  ).result.css()
+                                : '#999',
                           }}
                         />
                       </div>


### PR DESCRIPTION
This will address https://github.com/VEuPathDB/EdaNewIssues/issues/448. For now it is made as draft PR before confirmation of full-go. Below are screenshots:

a) Bangladesh is filtered
![scatter-legend-filter1](https://user-images.githubusercontent.com/12802305/197648619-2322526a-279b-4ba7-849c-f13a5dcb202d.png)

b) no smoothed mean for india and kenya due to small number of data
![scatter-legend-filter2](https://user-images.githubusercontent.com/12802305/197648699-c0f53f29-9362-477a-826a-ca53f0a94a2f.png)

