### PR TITLE
Fix red warning for bin width at limit of range

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/components",
-  "version": "0.19.6",
+  "version": "0.19.7",
   "license": "Apache-2.0",
   "description": "React Components for VEuPathDB Websites",
   "repository": {

--- a/src/components/widgets/NumberAndDateInputs.tsx
+++ b/src/components/widgets/NumberAndDateInputs.tsx
@@ -131,8 +131,10 @@ function BaseInput({
             message: `Sorry, value can't go above ${maxValue}!`,
           };
         } else if (
-          (minValue != null && newValue === minValue) ||
-          (maxValue != null && newValue === maxValue)
+          minValue != null &&
+          newValue === minValue &&
+          maxValue != null &&
+          newValue === maxValue
         ) {
           return {
             validity: false,


### PR DESCRIPTION
Resolves https://github.com/VEuPathDB/web-eda/issues/872

Solves the issue where the numeric bin width slider input is outlined red when at an allowed lower or upper limit.
Adjusting the bin width to the min or max was only possible with the slider, not the number input.
![image](https://user-images.githubusercontent.com/308639/198394360-a09d9df8-cdad-42f2-9c40-434fe2f27426.png)
