### PR TITLE
handling html tags at y-axis label tooltip

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/components",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "license": "Apache-2.0",
   "description": "React Components for VEuPathDB Websites",
   "repository": {

--- a/src/plots/PlotlyPlot.tsx
+++ b/src/plots/PlotlyPlot.tsx
@@ -27,6 +27,7 @@ import { ToImgopts, toImage } from 'plotly.js';
 import { uniqueId } from 'lodash';
 import { makeSharedPromise } from '../utils/promise-utils';
 import NoDataOverlay from '../components/NoDataOverlay';
+import { removeHtmlTags } from '../utils/removeHtmlTags';
 
 export interface PlotProps<T> extends ColorPaletteAddon {
   /** plot data - following web-components' API, not Plotly's */
@@ -223,7 +224,7 @@ function PlotlyPlot<T>(
         .selectAll('g.traces')
         .append('svg:title')
         .text((d: any) => {
-          return storedLegendList[d[0].trace.index];
+          return removeHtmlTags(storedLegendList[d[0].trace.index]);
         });
 
       // legend title tooltip
@@ -240,7 +241,7 @@ function PlotlyPlot<T>(
         select(graphDiv)
           .select('g.legend g.scrollbox text.legendtitletext')
           .append('svg:title')
-          .text(legendTitle);
+          .text(removeHtmlTags(legendTitle));
       }
 
       // independent axis tick label for barplot and boxplot
@@ -268,7 +269,7 @@ function PlotlyPlot<T>(
           .append('svg:title')
           .text((d, i) => {
             return storedIndependentAxisTickLabel != null
-              ? (storedIndependentAxisTickLabel[i] as string)
+              ? removeHtmlTags(storedIndependentAxisTickLabel[i] as string)
               : '';
           });
       }
@@ -293,13 +294,7 @@ function PlotlyPlot<T>(
           // need this attribute for tooltip of dependent axis title!
           .attr('pointer-events', 'all')
           .append('svg:title')
-          // remove html tags
-          .text(
-            (originalDependentAxisTitle as string).replace(
-              /[<b></b><i></i><br>]/g,
-              ''
-            ) as string
-          );
+          .text(removeHtmlTags(originalDependentAxisTitle as string) as string);
       }
     },
     [

--- a/src/plots/PlotlyPlot.tsx
+++ b/src/plots/PlotlyPlot.tsx
@@ -293,7 +293,13 @@ function PlotlyPlot<T>(
           // need this attribute for tooltip of dependent axis title!
           .attr('pointer-events', 'all')
           .append('svg:title')
-          .text(originalDependentAxisTitle as string);
+          // remove html tags
+          .text(
+            (originalDependentAxisTitle as string).replace(
+              /[<b></b><i></i><br>]/g,
+              ''
+            ) as string
+          );
       }
     },
     [

--- a/src/stories/plots/LinePlot.stories.tsx
+++ b/src/stories/plots/LinePlot.stories.tsx
@@ -164,7 +164,7 @@ Faceted.args = {
   },
 };
 
-//DKDK testing log scale
+// testing log scale
 const dataSetLog = {
   series: [
     {
@@ -224,6 +224,28 @@ const TemplateWithSelectedRangeControls: Story<Omit<LinePlotProps, 'data'>> = (
 
 export const LogScale = TemplateWithSelectedRangeControls.bind({});
 LogScale.args = {
+  containerStyles: {
+    height: '450px',
+    width: '750px',
+  },
+};
+
+// testing svg text (tooltip) for a dependent axis label with html tags
+export const YAxisLabelWithHtml: Story<Omit<LinePlotProps, 'data'>> = (
+  args
+) => {
+  return (
+    <LinePlot
+      data={undefined}
+      {...args}
+      dependentAxisLabel={
+        '<b><i>Arithmetic mean:</i></b><br> Plasmodium asexual stages, by microscopy result'
+      }
+    />
+  );
+};
+
+YAxisLabelWithHtml.args = {
   containerStyles: {
     height: '450px',
     width: '750px',

--- a/src/stories/plots/LinePlot.stories.tsx
+++ b/src/stories/plots/LinePlot.stories.tsx
@@ -239,7 +239,7 @@ export const YAxisLabelWithHtml: Story<Omit<LinePlotProps, 'data'>> = (
       data={undefined}
       {...args}
       dependentAxisLabel={
-        '<b><i>Arithmetic mean:</i></b><br> Plasmodium asexual stages, by microscopy result'
+        '<b><i>Arithmetic mean:</i></b><br /> Plasmodium asexual stages, by microscopy result'
       }
     />
   );

--- a/src/utils/removeHtmlTags.ts
+++ b/src/utils/removeHtmlTags.ts
@@ -1,0 +1,15 @@
+/**
+ * This will remove html tags from string in a format of <tags>
+ * <b>, </b>, <i>, </i>, <br>, <br />
+ */
+
+export function removeHtmlTags(str: string) {
+  if (str === null || str === '') return str;
+  else {
+    // removing tags for a format of <tags>
+    // return str.replace( /(<([^>]+)>)/gi, '');
+    // removing specific tags
+    const regexp = new RegExp('(?:</?b>|</?i>|<br\\s*/?>)', 'gi');
+    return str.replace(regexp, '');
+  }
+}


### PR DESCRIPTION
This PR is related to https://github.com/VEuPathDB/web-eda/issues/1433

I figured it out that dependent axis label can take html tags like `<b>, <i>, <br>`, however, its tooltip, which is actually SVG text attribute, still shows such tags as string. Thus, it is necessary to remove tags for tooltip string.

I also made a story to test this, as shown in the following screenshot. Those tags are not shown in the tooltip.

![lineplot-yAxis-label1](https://user-images.githubusercontent.com/12802305/199787897-ca9b808b-30bd-4959-831c-47a2f0c1d754.png)
