### PR TITLE
change the order of Mosaic color

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/components",
-  "version": "0.19.7",
+  "version": "0.19.8",
   "license": "Apache-2.0",
   "description": "React Components for VEuPathDB Websites",
   "repository": {

--- a/src/plots/MosaicPlot.tsx
+++ b/src/plots/MosaicPlot.tsx
@@ -11,7 +11,7 @@ import _ from 'lodash';
 // util functions for handling long tick labels with ellipsis
 import { axisTickLableEllipsis } from '../utils/axis-tick-label-ellipsis';
 import { makeStyles } from '@material-ui/core/styles';
-import { PlotSpacingDefault } from '../types/plots/addOns';
+import { PlotSpacingDefault, ColorPaletteDefault } from '../types/plots/addOns';
 import { Layout } from 'plotly.js';
 
 export interface MosaicPlotProps extends PlotProps<MosaicPlotData> {
@@ -219,7 +219,7 @@ const MosaicPlot = makePlotlyPlotComponent(
                 width: 1,
                 color: 'white',
               },
-              color: colors ? colors[i] : undefined,
+              color: colors ? colors[i] : ColorPaletteDefault[i],
             },
             legendgroup: data.dependentLabels[i],
             legendrank: i,


### PR DESCRIPTION
This will address https://github.com/VEuPathDB/web-eda/issues/1435

Initially, more complicated approach was used to address this issue by changing PlotlyPlot component, however, it was found that there was much simpler way. 

Here is a screenshot using the same example case in the ticket:

![mosaic-color1](https://user-images.githubusercontent.com/12802305/201238353-888ea677-21a3-4a00-be89-5e711c6d4b22.png)
