### PR TITLE
add padding for boxplot markers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/components",
-  "version": "0.19.8",
+  "version": "0.19.9",
   "license": "Apache-2.0",
   "description": "React Components for VEuPathDB Websites",
   "repository": {

--- a/src/plots/Boxplot.tsx
+++ b/src/plots/Boxplot.tsx
@@ -172,7 +172,8 @@ const Boxplot = makePlotlyPlotComponent('Boxplot', (props: BoxplotProps) => {
     standardDependentAxisRange,
     axisTruncationConfig?.dependentAxis,
     // for now, handle number only
-    'number'
+    'number',
+    true // addPadding
   ) as NumberRange | undefined;
 
   // make rectangular layout shapes for truncated axis/missing data


### PR DESCRIPTION
This will address https://github.com/VEuPathDB/web-eda/issues/1472

Realized that we already had a padding function for other plots such as scatterplot and lineplot, so the same is used for this boxplot.

For the same example shown in the original ticket, adding a padding would look like below:
![boxplot-add-padding1](https://user-images.githubusercontent.com/12802305/201760580-68ba015d-92d7-4d64-8e6d-d1ae4d536e23.png)
