### PR TITLE
fix a chartmarker bug

### DIFF
--- a/src/map/ChartMarker.tsx
+++ b/src/map/ChartMarker.tsx
@@ -269,8 +269,8 @@ function chartMarkerSVGIcon(
       ' height=' +
       barHeight +
       ' fill=' +
-      // rgb strings with spaces in them don't work in SVG?
-      (el.color ?? '').replace(/\s/g, '') +
+      // empty string does not work: filled with white rgb
+      (el.color ?? 'rgb(255,255,255)').replace(/\s/g, '') +
       ' />';
   });
 

--- a/src/map/ChartMarker.tsx
+++ b/src/map/ChartMarker.tsx
@@ -270,7 +270,7 @@ function chartMarkerSVGIcon(
       barHeight +
       ' fill=' +
       // empty string does not work: filled with white rgb
-      (el.color ?? 'rgb(255,255,255)').replace(/\s/g, '') +
+      (el.color ?? 'rgb(192,192,192))').replace(/\s/g, '') +
       ' />';
   });
 

--- a/src/stories/ChartMarkers.stories.tsx
+++ b/src/stories/ChartMarkers.stories.tsx
@@ -336,3 +336,29 @@ export const Standalone: Story<MapVEuMapProps> = () => {
     />
   );
 };
+
+// test no data.color
+export const TestNoDataColor: Story<MapVEuMapProps> = () => {
+  return (
+    <ChartMarkerStandalone
+      data={[
+        {
+          label: 'Gaining control study',
+          value: 0,
+          // "color": "rgb(136,34,85)"
+        },
+        {
+          label: 'Sustaining control study',
+          value: 75,
+          color: 'rgb(136,204,238)',
+        },
+      ]}
+      cumulative={false}
+      isAtomic={false}
+      markerScale={1}
+      borderColor={'#AAAAAA'}
+      borderWidth={3.5}
+      containerStyles={{ margin: '10px' }}
+    />
+  );
+};


### PR DESCRIPTION
This will fix the bug I mentioned at https://github.com/VEuPathDB/web-eda/issues/1586

So, the issue was that some data/marker do not have color info, e.g., when data.value = 0 then no data.color exists, but svg does not like the empty value of `fill` attribute. Thus, I have added a dummy color (white) for no data.color. This manual assignment won't matter because if data.value = 0, then height of the data becomes 0 so its color is actually ignored anyway.

Here are screenshot after this fix: as compared to the problematic screenshots at the https://github.com/VEuPathDB/web-eda/issues/1586.

a) SCORE S. mansonni CRT study
![map-bug-no-data-color-fixed](https://user-images.githubusercontent.com/12802305/215612298-13e75f8b-bf3d-479d-995c-ff07405de52f.png)

b) SCORE Mozambique (Full screen map)
![mozambique map error fixed](https://user-images.githubusercontent.com/12802305/215612366-4c1189e0-caf9-461a-8730-833540544226.png)

