### PR TITLE
add condition for dtick in case of no data

### DIFF
--- a/src/plots/LinePlot.tsx
+++ b/src/plots/LinePlot.tsx
@@ -151,7 +151,8 @@ const LinePlot = makePlotlyPlotComponent('LinePlot', (props: LinePlotProps) => {
       ...tickSettings(
         independentAxisLogScale,
         extendedIndependentAxisRange,
-        independentValueType
+        independentValueType,
+        data.series.length
       ),
     },
     yaxis: {
@@ -181,7 +182,8 @@ const LinePlot = makePlotlyPlotComponent('LinePlot', (props: LinePlotProps) => {
       ...tickSettings(
         dependentAxisLogScale,
         extendedDependentAxisRange,
-        dependentValueType
+        dependentValueType,
+        data.series.length
       ),
     },
     // axis range control: add truncatedAxisHighlighting for layout.shapes

--- a/src/utils/tick-settings.ts
+++ b/src/utils/tick-settings.ts
@@ -11,7 +11,14 @@ interface tickSettingsType {
 export function tickSettings(
   logScale: boolean,
   range: NumberOrDateRange | undefined,
-  valueType: 'string' | 'number' | 'date' | 'longitude' | 'category' | undefined
+  valueType:
+    | 'string'
+    | 'number'
+    | 'date'
+    | 'longitude'
+    | 'category'
+    | undefined,
+  dataLength?: number
 ): tickSettingsType {
   const axisDtick =
     range != null && range.min != null && range.max != null && logScale
@@ -20,7 +27,7 @@ export function tickSettings(
 
   return {
     // tickformat is conflicted with exponentformat
-    dtick: axisDtick,
+    dtick: dataLength != null && dataLength === 0 ? undefined : axisDtick,
     showexponent: 'all',
     exponentformat:
       valueType === 'date' || (axisDtick != null && axisDtick < 1)


### PR DESCRIPTION
This PR is related to https://github.com/VEuPathDB/web-eda/issues/1503. It is only for a better display of log scale without data, so for a functionality wise, it does not matter much.