### PR TITLE
implementing reverse slider feature

### DIFF
--- a/src/components/widgets/Slider.tsx
+++ b/src/components/widgets/Slider.tsx
@@ -1,5 +1,9 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import {
+  makeStyles,
+  createMuiTheme,
+  ThemeProvider,
+} from '@material-ui/core/styles';
 import Slider from '@material-ui/core/Slider';
 import Typography from '@material-ui/core/Typography';
 
@@ -53,6 +57,8 @@ export type SliderWidgetProps = {
   showLimits?: boolean;
   /** Disable the slider. Default is false */
   disabled?: boolean;
+  /** is reversed slider? e.g., from max to min */
+  isReverseSlider?: boolean;
 };
 
 /** A customizable slider widget.
@@ -75,6 +81,8 @@ export default function SliderWidget({
   showTextInput,
   showLimits = false,
   disabled = false,
+  // reversed slider option
+  isReverseSlider = false,
 }: SliderWidgetProps) {
   // Used to track whether or not has mouse hovering over widget.
   const [focused, setFocused] = useState(false);
@@ -150,6 +158,12 @@ export default function SliderWidget({
   const valueLabelDisplay = showTextInput ? 'off' : 'auto';
   const fontColor = disabled ? MEDIUM_GRAY : DARK_GRAY; // don't use focus any more?
 
+  // create theme to change the direction of slider
+  // rtl: right to left; ltr: left to right
+  const theme = createMuiTheme({
+    direction: isReverseSlider ? 'rtl' : 'ltr',
+  });
+
   return (
     <div
       style={{
@@ -189,31 +203,35 @@ export default function SliderWidget({
       )}
       {showLimits && minimum != null && maximum != null && (
         <Typography style={{ color: fontColor, fontSize: '0.75em' }}>
-          {minimum}
+          {isReverseSlider ? maximum : minimum}
         </Typography>
       )}
-      <Slider
-        classes={{
-          root: classes.root,
-          rail: classes.rail,
-          track: classes.track,
-          thumb: classes.thumb,
-          valueLabel: classes.valueLabel,
-          disabled: classes.disabled,
-        }}
-        aria-label={label ?? 'slider'}
-        min={minimum}
-        max={maximum}
-        value={localValue ?? 0}
-        step={step}
-        valueLabelDisplay={valueLabelDisplay}
-        valueLabelFormat={valueFormatter}
-        onChange={handleChange}
-        disabled={disabled}
-      />
+      <ThemeProvider theme={theme}>
+        <Slider
+          classes={{
+            root: classes.root,
+            rail: classes.rail,
+            track: classes.track,
+            thumb: classes.thumb,
+            valueLabel: classes.valueLabel,
+            disabled: classes.disabled,
+          }}
+          aria-label={label ?? 'slider'}
+          min={minimum}
+          max={maximum}
+          value={localValue ?? 0}
+          step={step}
+          valueLabelDisplay={valueLabelDisplay}
+          valueLabelFormat={valueFormatter}
+          onChange={handleChange}
+          disabled={disabled}
+          // check whether reversed slider or not
+          track={isReverseSlider ? 'inverted' : 'normal'}
+        />
+      </ThemeProvider>
       {showLimits && minimum != null && maximum != null && (
         <Typography style={{ color: fontColor, fontSize: '0.75em' }}>
-          {maximum}
+          {isReverseSlider ? minimum : maximum}
         </Typography>
       )}
     </div>

--- a/src/stories/plots/ScatterPlot.stories.tsx
+++ b/src/stories/plots/ScatterPlot.stories.tsx
@@ -1716,7 +1716,7 @@ Faceted.args = {
 
 export const opacitySlider = () => {
   const disabled = false;
-  const [markerBodyOpacity, setMarkerBodyOpacity] = useState(0);
+  const [markerBodyOpacity, setMarkerBodyOpacity] = useState(0.5);
   const containerStyles = {
     height: 100,
     width: 425,
@@ -1728,8 +1728,12 @@ export const opacitySlider = () => {
     type: 'gradient',
     tooltip: '#aaa',
     knobColor: '#aaa',
+    // normal slider color: e.g., from 0 to 1
     trackGradientStart: '#fff',
     trackGradientEnd: '#000',
+    // reversed slider color: e.g., from 1 to 0
+    // trackGradientStart: '#000',
+    // trackGradientEnd: '#fff',
   };
 
   return (
@@ -1793,7 +1797,7 @@ export const opacitySlider = () => {
         // hide text form
         // showTextInput={true}
         step={0.1}
-        value={0}
+        value={markerBodyOpacity}
         debounceRateMs={250}
         onChange={(newValue: number) => {
           setMarkerBodyOpacity(newValue);
@@ -1804,6 +1808,8 @@ export const opacitySlider = () => {
         disabled={disabled}
         // test gradient color
         colorSpec={colorSpecProps}
+        // set isReverseSlider: true if reversed slider
+        isReverseSlider={false}
       />
     </>
   );

--- a/src/stories/widgets/Slider.stories.tsx
+++ b/src/stories/widgets/Slider.stories.tsx
@@ -136,3 +136,49 @@ AuxiliaryTextInputHugeNum.args = {
   showTextInput: true,
 };
 AuxiliaryTextInputHugeNum.argTypes = { ...Basic.argTypes };
+
+export const reversedGradientSlider: Story<SliderWidgetProps> = (args) => {
+  const [value, setValue] = useState<number | undefined>(0.5);
+
+  return (
+    <SliderWidget
+      minimum={0}
+      maximum={1}
+      step={0.1}
+      value={value}
+      debounceRateMs={250}
+      onChange={(newValue: number) => {
+        setValue(newValue);
+      }}
+      containerStyles={markerBodyOpacityContainerStyles}
+      showLimits={true}
+      label={'Marker opacity'}
+      colorSpec={colorSpecProps}
+      showTextInput={false}
+      // set isReverseSlider: true if reversed slider
+      isReverseSlider={false}
+    />
+  );
+};
+
+// slider settings
+const markerBodyOpacityContainerStyles = {
+  height: '4em',
+  width: '30em',
+  marginLeft: '1em',
+  marginBottom: '0.5em',
+  marginTop: '5em',
+};
+
+// implement gradient color for slider opacity
+const colorSpecProps: SliderWidgetProps['colorSpec'] = {
+  type: 'gradient',
+  tooltip: '#aaa',
+  knobColor: '#aaa',
+  // normal slider color: e.g., from 0 to 1
+  trackGradientStart: '#fff',
+  trackGradientEnd: '#000',
+  // reversed slider color: e.g., from 1 to 0
+  // trackGradientStart: '#000',
+  // trackGradientEnd: '#fff',
+};


### PR DESCRIPTION
This is related to https://github.com/VEuPathDB/EdaNewIssues/issues/541. 

I missed the latest comment on the ticket so I implemented a new feature, reverse slider, which can be used if necessary. To utilize a reverse slider, two settings should be changed. 

a) isReverseSlider: true (default is false)
b) change trackGradientStart and trackGradientEnd to reflect appropriate colors

Added a story at Slider.stories.tsx to take a look at how it works.

A screenshot is attached. 
![reversed slider01](https://user-images.githubusercontent.com/12802305/217879350-44f84464-0859-4194-9f4e-9b8ba81e5f9c.png)
