### PR TITLE
set decimal points for colormap ticks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/components",
-  "version": "0.20.4",
+  "version": "0.20.5",
   "license": "Apache-2.0",
   "description": "React Components for VEuPathDB Websites",
   "repository": {

--- a/src/components/plotControls/PlotGradientLegend.tsx
+++ b/src/components/plotControls/PlotGradientLegend.tsx
@@ -77,9 +77,10 @@ export default function PlotGradientLegend({
           dominantBaseline="middle"
           fontSize={tickFontSize}
         >
-          {((a / (nTicks! - 1)) * (legendMax - legendMin) + legendMin).toFixed(
-            2
-          )}
+          {(
+            (a / (nTicks! - 1)) * (legendMax - legendMin) +
+            legendMin
+          ).toPrecision(3)}
         </text>
       </g>
     );

--- a/src/components/plotControls/PlotGradientLegend.tsx
+++ b/src/components/plotControls/PlotGradientLegend.tsx
@@ -77,11 +77,16 @@ export default function PlotGradientLegend({
           dominantBaseline="middle"
           fontSize={tickFontSize}
         >
-          {(a / (nTicks! - 1)) * (legendMax - legendMin) + legendMin}
+          {((a / (nTicks! - 1)) * (legendMax - legendMin) + legendMin).toFixed(
+            2
+          )}
         </text>
       </g>
     );
   });
+
+  //DKDK
+  console.log('ticks =', ticks);
 
   return (
     <div>

--- a/src/components/plotControls/PlotGradientLegend.tsx
+++ b/src/components/plotControls/PlotGradientLegend.tsx
@@ -86,9 +86,6 @@ export default function PlotGradientLegend({
     );
   });
 
-  //DKDK
-  console.log('ticks =', ticks);
-
   return (
     <div>
       <svg id="gradientLegend" height={gradientBoxHeight + 20} width={150}>


### PR DESCRIPTION
This is related to https://github.com/VEuPathDB/web-components/issues/454. 

While I was working on the colormap range, I noticed that the decimal points in the colormap's tick labels were often too long, so I have set it up to be 2 decimal points. Following is an example based on storybook.

a) without setting decimal points
![decimal-points-no](https://user-images.githubusercontent.com/12802305/226764651-ca7883bf-5319-47aa-a322-9e4001e4ffb6.png)

b) two digit decimal points
![decimal-points-2](https://user-images.githubusercontent.com/12802305/226764678-656008e5-24e4-436f-a822-6f2a5f626065.png)
